### PR TITLE
Add Saving and Loading Presets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "jack"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,6 +3033,7 @@ dependencies = [
  "log",
  "rubato",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3051,6 +3058,12 @@ dependencies = [
  "unicode-properties",
  "unicode-script",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3110,6 +3123,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4"
 clap = {version = "4.5", features = ["derive", "env"] }
 rubato = "0.16"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 crossbeam = "0.8"
 iced = "0.13"
 log = "0.4"

--- a/presets/Clean.json
+++ b/presets/Clean.json
@@ -1,0 +1,35 @@
+{
+  "name": "Clean",
+  "description": "Clean and pristine tone with subtle warmth",
+  "author": "Rustortion",
+  "stages": [
+    {
+      "Filter": {
+        "filter_type": "Highpass",
+        "cutoff_hz": 80.0,
+        "resonance": 0.0
+      }
+    },
+    {
+      "Preamp": {
+        "gain": 2.0,
+        "bias": 0.0,
+        "clipper_type": "Soft"
+      }
+    },
+    {
+      "ToneStack": {
+        "model": "American",
+        "bass": 0.6,
+        "mid": 0.5,
+        "treble": 0.7,
+        "presence": 0.4
+      }
+    },
+    {
+      "Level": {
+        "gain": 0.8
+      }
+    }
+  ]
+}

--- a/presets/Crunch.json
+++ b/presets/Crunch.json
@@ -1,0 +1,44 @@
+{
+  "name": "Crunch",
+  "description": "Classic rock crunch with mid-forward character",
+  "author": "Rustortion",
+  "stages": [
+    {
+      "Filter": {
+        "filter_type": "Highpass",
+        "cutoff_hz": 100.0,
+        "resonance": 0.1
+      }
+    },
+    {
+      "Preamp": {
+        "gain": 6.0,
+        "bias": 0.1,
+        "clipper_type": "Medium"
+      }
+    },
+    {
+      "ToneStack": {
+        "model": "British",
+        "bass": 0.5,
+        "mid": 0.7,
+        "treble": 0.6,
+        "presence": 0.5
+      }
+    },
+    {
+      "Compressor": {
+        "attack_ms": 2.0,
+        "release_ms": 50.0,
+        "threshold_db": -15.0,
+        "ratio": 3.0,
+        "makeup_db": 3.0
+      }
+    },
+    {
+      "Level": {
+        "gain": 0.9
+      }
+    }
+  ]
+}

--- a/presets/Lead.json
+++ b/presets/Lead.json
@@ -1,0 +1,44 @@
+{
+  "name": "Lead",
+  "description": "High-gain lead tone with sustain and clarity",
+  "author": "Rustortion",
+  "stages": [
+    {
+      "Filter": {
+        "filter_type": "Highpass",
+        "cutoff_hz": 120.0,
+        "resonance": 0.2
+      }
+    },
+    {
+      "Preamp": {
+        "gain": 8.5,
+        "bias": 0.0,
+        "clipper_type": "Asymmetric"
+      }
+    },
+    {
+      "ToneStack": {
+        "model": "Modern",
+        "bass": 0.4,
+        "mid": 0.8,
+        "treble": 0.7,
+        "presence": 0.6
+      }
+    },
+    {
+      "Compressor": {
+        "attack_ms": 1.0,
+        "release_ms": 80.0,
+        "threshold_db": -12.0,
+        "ratio": 4.0,
+        "makeup_db": 6.0
+      }
+    },
+    {
+      "Level": {
+        "gain": 1.1
+      }
+    }
+  ]
+}

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -169,11 +169,11 @@ impl AmplifierApp {
                                 self.selected_preset = Some(first_preset.name.clone());
                                 self.preset_bar
                                     .set_selected_preset(Some(first_preset.name.clone()));
-                                should_update_chain = true;
                             } else {
                                 self.stages.clear();
-                                should_update_chain = true;
                             }
+
+                            should_update_chain = true;
                         }
                     }
                     Err(e) => {

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -1,28 +1,64 @@
 use iced::{Element, Length, Task, Theme};
 use log::{error, info};
 
-use crate::gui::components::{control::Control, stage_list::StageList};
+use crate::gui::components::{control::Control, preset_bar::PresetBar, stage_list::StageList};
 use crate::gui::config::{StageConfig, StageType};
 use crate::gui::messages::{Message, StageMessage};
+use crate::gui::preset::{Preset, PresetManager};
 use crate::io::manager::ProcessorManager;
 use crate::sim::chain::AmplifierChain;
 
-#[derive(Debug)]
 pub struct AmplifierApp {
     processor_manager: ProcessorManager,
     stages: Vec<StageConfig>,
     selected_stage_type: StageType,
     is_recording: bool,
+    preset_manager: PresetManager,
+    selected_preset: Option<String>,
+    preset_bar: PresetBar,
+    new_preset_name: String,
+    show_save_input: bool,
 }
 
 impl AmplifierApp {
     pub fn new(processor_manager: ProcessorManager) -> Self {
-        Self {
+        let preset_manager = PresetManager::new("./presets").unwrap_or_else(|e| {
+            error!("Failed to create preset manager: {e}");
+            // Create an empty preset manager as fallback
+            PresetManager::new(std::env::temp_dir().join("rustortion_presets_fallback"))
+                .expect("Failed to create fallback preset manager")
+        });
+
+        let presets = preset_manager.get_presets();
+        let selected_preset = presets.first().map(|p| p.name.clone());
+        let preset_bar = PresetBar::new(presets, selected_preset.clone());
+
+        // Load the first preset if available
+        let stages = if let Some(preset_name) = &selected_preset {
+            preset_manager
+                .get_preset_by_name(preset_name)
+                .map(|p| p.stages.clone())
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+        let app = Self {
             processor_manager,
-            stages: Vec::new(),
+            stages,
             selected_stage_type: StageType::default(),
             is_recording: false,
-        }
+            preset_manager,
+            selected_preset,
+            preset_bar,
+            new_preset_name: String::new(),
+            show_save_input: false,
+        };
+
+        // Update the processor chain with the loaded preset
+        app.update_processor_chain();
+
+        app
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
@@ -54,6 +90,103 @@ impl AmplifierApp {
             }
             Message::StageTypeSelected(stage_type) => {
                 self.selected_stage_type = stage_type;
+            }
+            Message::PresetSelected(preset_name) => {
+                if let Some(preset) = self.preset_manager.get_preset_by_name(&preset_name) {
+                    self.stages = preset.stages.clone();
+                    self.selected_preset = Some(preset_name.clone());
+                    self.preset_bar
+                        .set_selected_preset(Some(preset_name.clone()));
+                    should_update_chain = true;
+                    info!("Loaded preset: {preset_name}");
+                }
+            }
+            Message::ShowSavePreset => {
+                self.show_save_input = true;
+                self.preset_bar.show_save_input(true);
+            }
+            Message::CancelSavePreset => {
+                self.show_save_input = false;
+                self.new_preset_name.clear();
+                self.preset_bar.show_save_input(false);
+            }
+            Message::PresetNameChanged(name) => {
+                self.new_preset_name = name.clone();
+                self.preset_bar.set_new_preset_name(name);
+            }
+            Message::SavePreset => {
+                if !self.new_preset_name.trim().is_empty() {
+                    let preset = Preset::new(self.new_preset_name.clone(), self.stages.clone());
+
+                    match self.preset_manager.save_preset(&preset) {
+                        Ok(()) => {
+                            info!("Saved preset: {}", self.new_preset_name);
+                            self.selected_preset = Some(self.new_preset_name.clone());
+                            self.preset_bar
+                                .update_presets(self.preset_manager.get_presets());
+                            self.preset_bar
+                                .set_selected_preset(Some(self.new_preset_name.clone()));
+                            self.show_save_input = false;
+                            self.preset_bar.show_save_input(false);
+                            self.new_preset_name.clear();
+                        }
+                        Err(e) => {
+                            error!("Failed to save preset: {e}");
+                        }
+                    }
+                }
+            }
+            Message::UpdateCurrentPreset => {
+                if let Some(ref preset_name) = self.selected_preset {
+                    let preset = Preset::new(preset_name.clone(), self.stages.clone());
+
+                    match self.preset_manager.save_preset(&preset) {
+                        Ok(()) => {
+                            info!("Updated preset: {preset_name}");
+                            self.preset_bar
+                                .update_presets(self.preset_manager.get_presets());
+                        }
+                        Err(e) => {
+                            error!("Failed to update preset: {e}");
+                        }
+                    }
+                }
+            }
+            Message::DeletePreset(preset_name) => {
+                match self.preset_manager.delete_preset(&preset_name) {
+                    Ok(()) => {
+                        info!("Deleted preset: {preset_name}");
+                        self.preset_bar
+                            .update_presets(self.preset_manager.get_presets());
+
+                        // Clear selection if we deleted the current preset
+                        if self.selected_preset.as_ref() == Some(&preset_name) {
+                            self.selected_preset = None;
+                            self.preset_bar.set_selected_preset(None);
+                            // Optionally load the first available preset or clear stages
+                            if let Some(first_preset) = self.preset_manager.get_presets().first() {
+                                self.stages = first_preset.stages.clone();
+                                self.selected_preset = Some(first_preset.name.clone());
+                                self.preset_bar
+                                    .set_selected_preset(Some(first_preset.name.clone()));
+                                should_update_chain = true;
+                            } else {
+                                self.stages.clear();
+                                should_update_chain = true;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("Failed to delete preset: {e}");
+                    }
+                }
+            }
+            Message::ConfirmOverwritePreset => {
+                self.save_current_preset();
+                self.preset_bar.hide_overwrite_confirmation();
+            }
+            Message::CancelOverwritePreset => {
+                self.preset_bar.hide_overwrite_confirmation();
             }
             Message::StartRecording => match self.processor_manager.enable_recording() {
                 Ok(()) => {
@@ -149,6 +282,26 @@ impl AmplifierApp {
         }
     }
 
+    fn save_current_preset(&mut self) {
+        let preset = Preset::new(self.new_preset_name.clone(), self.stages.clone());
+
+        match self.preset_manager.save_preset(&preset) {
+            Ok(()) => {
+                info!("Saved preset: {}", self.new_preset_name);
+                self.selected_preset = Some(self.new_preset_name.clone());
+                self.preset_bar
+                    .update_presets(self.preset_manager.get_presets());
+                self.preset_bar
+                    .set_selected_preset(Some(self.new_preset_name.clone()));
+                self.show_save_input = false;
+                self.preset_bar.show_save_input(false);
+                self.new_preset_name.clear();
+            }
+            Err(e) => {
+                error!("Failed to save preset: {e}");
+            }
+        }
+    }
     fn update_processor_chain(&self) {
         let sample_rate = self.processor_manager.sample_rate();
         let chain = build_amplifier_chain(&self.stages, sample_rate);
@@ -160,6 +313,7 @@ impl AmplifierApp {
 
         container(
             column![
+                self.preset_bar.view(),
                 StageList::new(&self.stages).view(),
                 Control::new(self.selected_stage_type, self.is_recording).view()
             ]

--- a/src/gui/components/mod.rs
+++ b/src/gui/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod control;
+pub mod preset_bar;
 pub mod stage_list;
 pub mod stages;
 pub mod widgets;

--- a/src/gui/components/preset_bar.rs
+++ b/src/gui/components/preset_bar.rs
@@ -1,0 +1,148 @@
+use iced::widget::{button, container, pick_list, row, text, text_input};
+use iced::{Alignment, Element, Length};
+
+use crate::gui::messages::Message;
+use crate::gui::preset::Preset;
+
+pub struct PresetBar {
+    available_presets: Vec<String>,
+    selected_preset: Option<String>,
+    new_preset_name: String,
+    show_save_input: bool,
+    show_overwrite_confirmation: bool,
+    overwrite_target: String,
+}
+
+impl PresetBar {
+    pub fn new(presets: &[Preset], selected_preset: Option<String>) -> Self {
+        let available_presets = presets.iter().map(|p| p.name.clone()).collect();
+
+        Self {
+            available_presets,
+            selected_preset,
+            new_preset_name: String::new(),
+            show_save_input: false,
+            show_overwrite_confirmation: false,
+            overwrite_target: String::new(),
+        }
+    }
+
+    pub fn update_presets(&mut self, presets: &[Preset]) {
+        self.available_presets = presets.iter().map(|p| p.name.clone()).collect();
+    }
+
+    pub fn set_selected_preset(&mut self, preset_name: Option<String>) {
+        self.selected_preset = preset_name;
+    }
+
+    pub fn set_new_preset_name(&mut self, name: String) {
+        self.new_preset_name = name;
+    }
+
+    pub fn show_save_input(&mut self, show: bool) {
+        self.show_save_input = show;
+        if !show {
+            self.new_preset_name.clear();
+            self.show_overwrite_confirmation = false;
+            self.overwrite_target.clear();
+        }
+    }
+
+    pub fn show_overwrite_confirmation(&mut self, preset_name: String) {
+        self.show_overwrite_confirmation = true;
+        self.overwrite_target = preset_name;
+    }
+
+    pub fn hide_overwrite_confirmation(&mut self) {
+        self.show_overwrite_confirmation = false;
+        self.overwrite_target.clear();
+    }
+
+    pub fn view(&self) -> Element<'static, Message> {
+        let preset_selector = row![
+            text("Preset:").width(Length::Fixed(80.0)),
+            pick_list(
+                self.available_presets.clone(),
+                self.selected_preset.clone(),
+                Message::PresetSelected
+            )
+            .width(Length::Fixed(200.0)),
+        ]
+        .spacing(10)
+        .align_y(Alignment::Center);
+
+        // Show overwrite confirmation dialog
+        if self.show_overwrite_confirmation {
+            let confirmation_controls = row![
+                text(format!("Overwrite '{}'?", self.overwrite_target)),
+                button("Yes").on_press(Message::ConfirmOverwritePreset),
+                button("No").on_press(Message::CancelOverwritePreset),
+            ]
+            .spacing(5)
+            .align_y(Alignment::Center);
+
+            return container(
+                row![
+                    preset_selector,
+                    iced::widget::horizontal_space(),
+                    confirmation_controls,
+                ]
+                .spacing(20)
+                .align_y(Alignment::Center)
+                .width(Length::Fill),
+            )
+            .padding(10)
+            .style(|theme: &iced::Theme| {
+                container::Style::default()
+                    .background(theme.palette().background)
+                    .border(iced::Border::default().rounded(5))
+            })
+            .into();
+        }
+
+        let save_controls = if self.show_save_input {
+            row![
+                text_input("Preset name...", &self.new_preset_name)
+                    .on_input(Message::PresetNameChanged)
+                    .width(Length::Fixed(150.0)),
+                button("Save").on_press(Message::SavePreset),
+                button("Cancel").on_press(Message::CancelSavePreset),
+            ]
+            .spacing(5)
+            .align_y(Alignment::Center)
+        } else {
+            let mut controls = row![button("Save As...").on_press(Message::ShowSavePreset),];
+
+            // Add Update and Delete buttons if a preset is selected
+            if let Some(ref preset_name) = self.selected_preset {
+                controls = controls
+                    .push(button("Update").on_press(Message::UpdateCurrentPreset))
+                    .push(
+                        button("Delete")
+                            .on_press(Message::DeletePreset(preset_name.clone()))
+                            .style(iced::widget::button::danger),
+                    );
+            }
+
+            controls.spacing(5).align_y(Alignment::Center)
+        };
+
+        container(
+            row![
+                preset_selector,
+                iced::widget::horizontal_space(),
+                save_controls,
+            ]
+            .spacing(20)
+            .align_y(Alignment::Center)
+            .width(Length::Fill),
+        )
+        .padding(10)
+        .style(|theme: &iced::Theme| {
+            container::Style::default()
+                .background(theme.palette().background)
+                .border(iced::Border::default().rounded(5))
+        })
+        .into()
+    }
+}

--- a/src/gui/config/compressor.rs
+++ b/src/gui/config/compressor.rs
@@ -1,6 +1,7 @@
 use crate::sim::stages::compressor::CompressorStage;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct CompressorConfig {
     pub attack_ms: f32,
     pub release_ms: f32,

--- a/src/gui/config/filter.rs
+++ b/src/gui/config/filter.rs
@@ -1,6 +1,7 @@
 use crate::sim::stages::filter::{FilterStage, FilterType};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct FilterConfig {
     pub filter_type: FilterType,
     pub cutoff_hz: f32,

--- a/src/gui/config/level.rs
+++ b/src/gui/config/level.rs
@@ -1,6 +1,7 @@
 use crate::sim::stages::level::LevelStage;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct LevelConfig {
     pub gain: f32,
 }

--- a/src/gui/config/mod.rs
+++ b/src/gui/config/mod.rs
@@ -12,8 +12,10 @@ pub use poweramp::PowerAmpConfig;
 pub use preamp::PreampConfig;
 pub use tonestack::ToneStackConfig;
 
+use serde::{Deserialize, Serialize};
+
 // Stage type enum
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StageType {
     #[default]
     Filter,
@@ -38,7 +40,7 @@ impl std::fmt::Display for StageType {
 }
 
 // Stage configurations
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum StageConfig {
     Filter(FilterConfig),
     Preamp(PreampConfig),

--- a/src/gui/config/poweramp.rs
+++ b/src/gui/config/poweramp.rs
@@ -1,6 +1,7 @@
 use crate::sim::stages::poweramp::{PowerAmpStage, PowerAmpType};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct PowerAmpConfig {
     pub drive: f32,
     pub amp_type: PowerAmpType,

--- a/src/gui/config/preamp.rs
+++ b/src/gui/config/preamp.rs
@@ -1,6 +1,7 @@
 use crate::sim::stages::{clipper::ClipperType, preamp::PreampStage};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct PreampConfig {
     pub gain: f32,
     pub bias: f32,

--- a/src/gui/config/tonestack.rs
+++ b/src/gui/config/tonestack.rs
@@ -1,6 +1,7 @@
 use crate::sim::stages::tonestack::{ToneStackModel, ToneStackStage};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct ToneStackConfig {
     pub model: ToneStackModel,
     pub bass: f32,

--- a/src/gui/messages.rs
+++ b/src/gui/messages.rs
@@ -12,6 +12,17 @@ pub enum Message {
     MoveStageDown(usize),
     StageTypeSelected(StageType),
 
+    // Preset settings
+    PresetSelected(String),
+    SavePreset,
+    CancelSavePreset,
+    ShowSavePreset,
+    PresetNameChanged(String),
+    UpdateCurrentPreset,
+    DeletePreset(String),
+    ConfirmOverwritePreset,
+    CancelOverwritePreset,
+
     // Recording messages
     StartRecording,
     StopRecording,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod components;
 pub mod config;
 pub mod messages;
+pub mod preset;
 
 pub use app::AmplifierApp;
 use iced::Font;

--- a/src/gui/preset.rs
+++ b/src/gui/preset.rs
@@ -24,13 +24,13 @@ impl Preset {
         }
     }
 
-    pub fn with_description(mut self, description: String) -> Self {
-        self.description = Some(description);
+    pub fn with_description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_string());
         self
     }
 
-    pub fn with_author(mut self, author: String) -> Self {
-        self.author = Some(author);
+    pub fn with_author(mut self, author: &str) -> Self {
+        self.author = Some(author.to_string());
         self
     }
 }
@@ -179,8 +179,8 @@ fn create_default_presets() -> Vec<Preset> {
                 StageConfig::Level(LevelConfig { gain: 0.8 }),
             ],
         )
-        .with_description("Clean and pristine tone with subtle warmth".to_string())
-        .with_author("Rustortion".to_string()),
+        .with_description("Clean and pristine tone with subtle warmth")
+        .with_author("Rustortion"),
         // Crunch preset
         Preset::new(
             "Crunch".to_string(),
@@ -212,8 +212,8 @@ fn create_default_presets() -> Vec<Preset> {
                 StageConfig::Level(LevelConfig { gain: 0.9 }),
             ],
         )
-        .with_description("Classic rock crunch with mid-forward character".to_string())
-        .with_author("Rustortion".to_string()),
+        .with_description("Classic rock crunch with mid-forward character")
+        .with_author("Rustortion"),
         // Lead preset
         Preset::new(
             "Lead".to_string(),
@@ -245,8 +245,8 @@ fn create_default_presets() -> Vec<Preset> {
                 StageConfig::Level(LevelConfig { gain: 1.1 }),
             ],
         )
-        .with_description("High-gain lead tone with sustain and clarity".to_string())
-        .with_author("Rustortion".to_string()),
+        .with_description("High-gain lead tone with sustain and clarity")
+        .with_author("Rustortion"),
     ]
 }
 

--- a/src/gui/preset.rs
+++ b/src/gui/preset.rs
@@ -1,0 +1,261 @@
+use anyhow::{Context, Result};
+use log::warn;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::gui::config::StageConfig;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Preset {
+    pub name: String,
+    pub description: Option<String>,
+    pub author: Option<String>,
+    pub stages: Vec<StageConfig>,
+}
+
+impl Preset {
+    pub fn new(name: String, stages: Vec<StageConfig>) -> Self {
+        Self {
+            name,
+            description: None,
+            author: None,
+            stages,
+        }
+    }
+
+    pub fn with_description(mut self, description: String) -> Self {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_author(mut self, author: String) -> Self {
+        self.author = Some(author);
+        self
+    }
+}
+
+pub struct PresetManager {
+    presets_dir: PathBuf,
+    presets: Vec<Preset>,
+}
+
+impl PresetManager {
+    pub fn new<P: AsRef<Path>>(presets_dir: P) -> Result<Self> {
+        let presets_dir = presets_dir.as_ref().to_path_buf();
+        fs::create_dir_all(&presets_dir).context("Failed to create presets directory")?;
+
+        let mut manager = Self {
+            presets_dir,
+            presets: Vec::new(),
+        };
+
+        manager.load_presets()?;
+        manager.ensure_default_presets()?;
+
+        Ok(manager)
+    }
+
+    pub fn load_presets(&mut self) -> Result<()> {
+        self.presets.clear();
+
+        if !self.presets_dir.exists() {
+            return Ok(());
+        }
+
+        for entry in fs::read_dir(&self.presets_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.extension().and_then(|s| s.to_str()) == Some("json") {
+                match self.load_preset_file(&path) {
+                    Ok(preset) => self.presets.push(preset),
+                    Err(e) => {
+                        warn!("Failed to load preset {path:?}: {e}");
+                    }
+                }
+            }
+        }
+
+        // Sort presets by name
+        self.presets.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(())
+    }
+
+    fn load_preset_file<P: AsRef<Path>>(&self, path: P) -> Result<Preset> {
+        let content = fs::read_to_string(path.as_ref()).context("Failed to read preset file")?;
+
+        serde_json::from_str(&content).context("Failed to parse preset JSON")
+    }
+
+    pub fn save_preset(&mut self, preset: &Preset) -> Result<()> {
+        let filename = format!("{}.json", sanitize_filename(&preset.name));
+        let path = self.presets_dir.join(filename);
+
+        let json = serde_json::to_string_pretty(preset).context("Failed to serialize preset")?;
+
+        fs::write(&path, json).context("Failed to write preset file")?;
+
+        // Reload presets to include the new/updated one
+        self.load_presets()?;
+
+        Ok(())
+    }
+
+    pub fn delete_preset(&mut self, preset_name: &str) -> Result<()> {
+        let filename = format!("{}.json", sanitize_filename(preset_name));
+        let path = self.presets_dir.join(filename);
+
+        if path.exists() {
+            fs::remove_file(&path).context("Failed to delete preset file")?;
+
+            // Reload presets to reflect the deletion
+            self.load_presets()?;
+
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("Preset file not found: {}", preset_name))
+        }
+    }
+
+    pub fn preset_exists(&self, name: &str) -> bool {
+        self.presets.iter().any(|p| p.name == name)
+    }
+
+    pub fn get_presets(&self) -> &[Preset] {
+        &self.presets
+    }
+
+    pub fn get_preset_by_name(&self, name: &str) -> Option<&Preset> {
+        self.presets.iter().find(|p| p.name == name)
+    }
+
+    fn ensure_default_presets(&mut self) -> Result<()> {
+        // Check if we already have presets
+        if !self.presets.is_empty() {
+            return Ok(());
+        }
+
+        // Create default presets
+        let default_presets = create_default_presets();
+
+        for preset in default_presets {
+            self.save_preset(&preset)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn create_default_presets() -> Vec<Preset> {
+    use crate::gui::config::*;
+    use crate::sim::stages::clipper::ClipperType;
+    use crate::sim::stages::filter::FilterType;
+    use crate::sim::stages::tonestack::ToneStackModel;
+
+    vec![
+        // Clean preset
+        Preset::new(
+            "Clean".to_string(),
+            vec![
+                StageConfig::Filter(FilterConfig {
+                    filter_type: FilterType::Highpass,
+                    cutoff_hz: 80.0,
+                    resonance: 0.0,
+                }),
+                StageConfig::Preamp(PreampConfig {
+                    gain: 2.0,
+                    bias: 0.0,
+                    clipper_type: ClipperType::Soft,
+                }),
+                StageConfig::ToneStack(ToneStackConfig {
+                    model: ToneStackModel::American,
+                    bass: 0.6,
+                    mid: 0.5,
+                    treble: 0.7,
+                    presence: 0.4,
+                }),
+                StageConfig::Level(LevelConfig { gain: 0.8 }),
+            ],
+        )
+        .with_description("Clean and pristine tone with subtle warmth".to_string())
+        .with_author("Rustortion".to_string()),
+        // Crunch preset
+        Preset::new(
+            "Crunch".to_string(),
+            vec![
+                StageConfig::Filter(FilterConfig {
+                    filter_type: FilterType::Highpass,
+                    cutoff_hz: 100.0,
+                    resonance: 0.1,
+                }),
+                StageConfig::Preamp(PreampConfig {
+                    gain: 6.0,
+                    bias: 0.1,
+                    clipper_type: ClipperType::Medium,
+                }),
+                StageConfig::ToneStack(ToneStackConfig {
+                    model: ToneStackModel::British,
+                    bass: 0.5,
+                    mid: 0.7,
+                    treble: 0.6,
+                    presence: 0.5,
+                }),
+                StageConfig::Compressor(CompressorConfig {
+                    attack_ms: 2.0,
+                    release_ms: 50.0,
+                    threshold_db: -15.0,
+                    ratio: 3.0,
+                    makeup_db: 3.0,
+                }),
+                StageConfig::Level(LevelConfig { gain: 0.9 }),
+            ],
+        )
+        .with_description("Classic rock crunch with mid-forward character".to_string())
+        .with_author("Rustortion".to_string()),
+        // Lead preset
+        Preset::new(
+            "Lead".to_string(),
+            vec![
+                StageConfig::Filter(FilterConfig {
+                    filter_type: FilterType::Highpass,
+                    cutoff_hz: 120.0,
+                    resonance: 0.2,
+                }),
+                StageConfig::Preamp(PreampConfig {
+                    gain: 8.5,
+                    bias: 0.0,
+                    clipper_type: ClipperType::Asymmetric,
+                }),
+                StageConfig::ToneStack(ToneStackConfig {
+                    model: ToneStackModel::Modern,
+                    bass: 0.4,
+                    mid: 0.8,
+                    treble: 0.7,
+                    presence: 0.6,
+                }),
+                StageConfig::Compressor(CompressorConfig {
+                    attack_ms: 1.0,
+                    release_ms: 80.0,
+                    threshold_db: -12.0,
+                    ratio: 4.0,
+                    makeup_db: 6.0,
+                }),
+                StageConfig::Level(LevelConfig { gain: 1.1 }),
+            ],
+        )
+        .with_description("High-gain lead tone with sustain and clarity".to_string())
+        .with_author("Rustortion".to_string()),
+    ]
+}
+
+fn sanitize_filename(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => c,
+            ' ' => '_',
+            _ => '_',
+        })
+        .collect()
+}


### PR DESCRIPTION
Closes #15 

 Adds functionality to save and load presets, serialises the stage configs to and from JSON and adds in the relevant GUI functionality. It's a little bit messy but gets the job done.

<img width="1636" height="1153" alt="Screenshot_20250802_120755" src="https://github.com/user-attachments/assets/e96e5aa5-cd9d-4d8a-8f92-94acac5784a3" />
