### PR TITLE
Rebuild on ticks rather than each update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2187590a23ab1e3df8681afdf0987c48504d80291f002fcdb651f0ef5e25169"
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +359,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "bit-set"
@@ -1384,6 +1408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1661,7 @@ dependencies = [
  "iced_core",
  "log",
  "rustc-hash 2.1.1",
+ "tokio",
  "wasm-bindgen-futures",
  "wasm-timer",
 ]
@@ -2429,6 +2460,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +3002,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,6 +3513,16 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "toml_datetime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rubato = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 crossbeam = "0.8"
-iced = "0.13"
+iced = { version = "0.13", features = ["tokio"] }
 log = "0.4"
 env_logger = "0.11"
 dotenv = "0.15"

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -87,7 +87,6 @@ impl AmplifierApp {
 
         match message {
             Message::RebuildTick => {
-                println!("Rebuild tick received");
                 if self.dirty_chain {
                     self.update_processor_chain();
                     self.dirty_chain = false;

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -1,4 +1,4 @@
-use iced::{Element, Length, Task, Theme};
+use iced::{Element, Length, Subscription, Task, Theme, time, time::Duration};
 use log::{error, info};
 
 use crate::gui::components::{
@@ -24,6 +24,8 @@ pub struct AmplifierApp {
     show_save_input: bool,
     settings: Settings,
     settings_dialog: SettingsDialog,
+
+    dirty_chain: bool,
 }
 
 impl AmplifierApp {
@@ -53,7 +55,7 @@ impl AmplifierApp {
         let control_bar = Control::new(StageType::default());
         let settings_dialog = SettingsDialog::new(&settings.audio);
 
-        let app = Self {
+        Self {
             processor_manager,
             stages,
             is_recording: false,
@@ -66,43 +68,55 @@ impl AmplifierApp {
             show_save_input: false,
             settings,
             settings_dialog,
-        };
 
-        // Update the processor chain with the loaded preset
-        app.update_processor_chain();
+            // Set dirty chain to true to trigger initial rebuild
+            dirty_chain: true,
+        }
+    }
 
-        app
+    pub fn subscription(&self) -> Subscription<Message> {
+        if self.dirty_chain {
+            time::every(Duration::from_millis(100)).map(|_| Message::RebuildTick)
+        } else {
+            Subscription::none()
+        }
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
-        let mut should_update_chain = false;
         let mut should_update_stages = false;
 
         match message {
+            Message::RebuildTick => {
+                println!("Rebuild tick received");
+                if self.dirty_chain {
+                    self.update_processor_chain();
+                    self.dirty_chain = false;
+                }
+            }
             Message::AddStage => {
                 let new_stage = StageConfig::create_default(self.control_bar.selected());
                 self.stages.push(new_stage);
-                should_update_chain = true;
+                self.dirty_chain = true;
                 should_update_stages = true;
             }
             Message::RemoveStage(idx) => {
                 if idx < self.stages.len() {
                     self.stages.remove(idx);
                 }
-                should_update_chain = true;
+                self.dirty_chain = true;
                 should_update_stages = true;
             }
             Message::MoveStageUp(idx) => {
                 if idx > 0 {
                     self.stages.swap(idx - 1, idx);
-                    should_update_chain = true;
+                    self.dirty_chain = true;
                     should_update_stages = true;
                 }
             }
             Message::MoveStageDown(idx) => {
                 if idx < self.stages.len().saturating_sub(1) {
                     self.stages.swap(idx, idx + 1);
-                    should_update_chain = true;
+                    self.dirty_chain = true;
                     should_update_stages = true;
                 }
             }
@@ -115,7 +129,7 @@ impl AmplifierApp {
                     self.selected_preset = Some(preset_name.clone());
                     self.preset_bar
                         .set_selected_preset(Some(preset_name.clone()));
-                    should_update_chain = true;
+                    self.dirty_chain = true;
                     should_update_stages = true;
                     info!("Loaded preset: {preset_name}");
                 }
@@ -192,7 +206,7 @@ impl AmplifierApp {
                                 self.stages.clear();
                             }
 
-                            should_update_chain = true;
+                            self.dirty_chain = true;
                         }
                     }
                     Err(e) => {
@@ -286,14 +300,10 @@ impl AmplifierApp {
             }
             Message::Stage(idx, stage_msg) => {
                 if self.update_stage(idx, stage_msg) {
-                    should_update_chain = true;
+                    self.dirty_chain = true;
                     should_update_stages = true
                 }
             }
-        }
-
-        if should_update_chain {
-            self.update_processor_chain();
         }
 
         if should_update_stages {

--- a/src/gui/messages.rs
+++ b/src/gui/messages.rs
@@ -11,6 +11,7 @@ pub enum Message {
     MoveStageUp(usize),
     MoveStageDown(usize),
     StageTypeSelected(StageType),
+    RebuildTick,
 
     // Preset settings
     PresetSelected(String),

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -15,6 +15,7 @@ pub const DEFAULT_FONT: Font = Font::MONOSPACE;
 
 pub fn start(processor_manager: ProcessorManager, settings: Settings) -> iced::Result {
     iced::application("Rustortion", AmplifierApp::update, AmplifierApp::view)
+        .subscription(AmplifierApp::subscription)
         .window_size((800.0, 600.0))
         .theme(AmplifierApp::theme)
         .default_font(DEFAULT_FONT)


### PR DESCRIPTION
If the amp needs to be rebuilt do it on a 100ms tick instead of every update, so stuff like sliders etc doesn't cause an insane amount of amp updates