### PR TITLE
issue #110- enabled aggressive optimization for the dist profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,5 @@ harness = false
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+codegen-units = 1
+lto = true


### PR DESCRIPTION
Added 
```
[profile.dist]
inherits = "release"
codegen-units = 1
lto = true
``` 
to cargo.toml