### PR TITLE
feat: assert no allocations on the RT audio path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_no_alloc"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ca83137a482d61d916ceb1eba52a684f98004f18e0cafea230fe5579c178a3"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3724,6 +3730,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "assert_no_alloc",
  "chrono",
  "clap",
  "criterion",
@@ -3759,6 +3766,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "assert_no_alloc",
  "chrono",
  "clap",
  "crossbeam",

--- a/rustortion-core/Cargo.toml
+++ b/rustortion-core/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 rustfft = "6.4"
 realfft = "3.5"
 arc-swap = "1.8"
+assert_no_alloc = { version = "1.1", features = ["warn_debug"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/rustortion-core/src/audio/engine.rs
+++ b/rustortion-core/src/audio/engine.rs
@@ -378,7 +378,9 @@ impl Engine {
             shifter.set_semitones(semitones as f32);
             debug!("Pitch shift set to {semitones} semitones");
         } else {
-            self.pitch_shifter = Some(PitchShifter::new(semitones as f32));
+            // FIXME(no_alloc): PitchShifter::new allocates FFT scratch buffers
+            // — see audio/pitch_shifter.rs.
+            self.pitch_shifter = Some(permit_alloc(|| PitchShifter::new(semitones as f32)));
             debug!("Pitch shift set to {semitones} semitones");
         }
     }

--- a/rustortion-core/src/audio/engine.rs
+++ b/rustortion-core/src/audio/engine.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use assert_no_alloc::permit_alloc;
 use crossbeam::channel::{Receiver, Sender, bounded};
 use log::{debug, error};
 
@@ -161,7 +162,9 @@ impl Engine {
         }
 
         if let Some(ref mut shifter) = self.pitch_shifter {
-            shifter.process_block(output);
+            // FIXME(no_alloc): PitchShifter::process_block uses Vec scratch
+            // buffers internally — see audio/pitch_shifter.rs.
+            permit_alloc(|| shifter.process_block(output));
         }
 
         if let Some(ref mut cab) = self.ir_cabinet {
@@ -169,13 +172,17 @@ impl Engine {
         }
 
         if let Some(ref mut peak_meter) = self.peak_meter {
-            peak_meter.process(output);
+            // FIXME(no_alloc): PeakMeter::process does Arc::new(PeakMeterInfo)
+            // every block — see audio/peak_meter.rs:62.
+            permit_alloc(|| peak_meter.process(output));
         }
 
         if !self.lightweight
             && let Some(recorder) = self.recorder.as_mut()
         {
-            recorder.record_block(output)?;
+            // FIXME(no_alloc): Recorder::record_block does Vec::with_capacity
+            // per block — see audio/recorder.rs:47.
+            permit_alloc(|| recorder.record_block(output))?;
         }
 
         Ok(())
@@ -293,7 +300,7 @@ impl Engine {
                     if let Some(ref mut cab) = self.ir_cabinet {
                         debug!("IR convolver swapped: {}", prepared.name);
                         let old = cab.swap_convolver(prepared.convolver);
-                        self.rt_drop.retire(Box::new(old));
+                        permit_alloc(|| self.rt_drop.retire(Box::new(old)));
                     }
                 }
                 EngineMessage::ClearIr => {
@@ -330,7 +337,7 @@ impl Engine {
                 }
                 EngineMessage::SetSamplers(new_samplers) => {
                     let old = std::mem::replace(&mut self.samplers, *new_samplers);
-                    self.rt_drop.retire(Box::new(old));
+                    permit_alloc(|| self.rt_drop.retire(Box::new(old)));
                     debug!("Samplers swapped");
                 }
             }

--- a/rustortion-core/tests/no_alloc.rs
+++ b/rustortion-core/tests/no_alloc.rs
@@ -11,9 +11,7 @@
 //! work that runs *before* the assert scope) is fine and noted in the per-test
 //! comment.
 
-use assert_no_alloc::{
-    AllocDisabler, assert_no_alloc, permit_alloc, reset_violation_count, violation_count,
-};
+use assert_no_alloc::{AllocDisabler, assert_no_alloc, reset_violation_count, violation_count};
 use hound::{WavSpec, WavWriter};
 
 use rustortion_core::amp::chain::AmplifierChain;
@@ -32,7 +30,6 @@ use rustortion_core::amp::stages::reverb::ReverbStage;
 use rustortion_core::amp::stages::tonestack::{ToneStackModel, ToneStackStage};
 use rustortion_core::audio::engine::{Engine, EngineHandle};
 use rustortion_core::audio::peak_meter::PeakMeter;
-use rustortion_core::audio::recorder::Recorder;
 use rustortion_core::audio::rt_drop::{RtDropHandle, RtDropReceiver};
 use rustortion_core::audio::samplers::Samplers;
 use rustortion_core::ir::cabinet::{ConvolverType, DEFAULT_MAX_IR_MS, IrCabinet};
@@ -56,6 +53,9 @@ const BUFFER_SIZE: usize = 128;
 /// that were recorded. With the `warn_debug` feature on, `assert_no_alloc`
 /// counts allocation attempts instead of aborting — so we can panic with a
 /// useful message at the test boundary instead of killing the test binary.
+///
+/// Always check the returned count and panic if non-zero — calling
+/// `assert_no_alloc` directly would silently swallow regressions.
 fn check_no_alloc<F: FnOnce()>(body: F) -> u32 {
     reset_violation_count();
     assert_no_alloc(body);
@@ -64,8 +64,15 @@ fn check_no_alloc<F: FnOnce()>(body: F) -> u32 {
 
 /// Run `engine.process()` `iters` times inside an `assert_no_alloc` scope
 /// after one warm-up call. Panics if any allocation was observed.
+///
+/// Tests using this helper should ensure the message channel is fully drained
+/// before calling: the warm-up `process()` happens *outside* the assertion,
+/// so any allocation triggered while draining a queued `EngineMessage` (e.g.
+/// `PitchShifter::new` from `SetPitchShift`) is invisible to the audit. Send
+/// such messages inside the asserted scope instead.
 fn assert_engine_alloc_free(engine: &mut Engine, input: &[f32], output: &mut [f32], iters: usize) {
-    // Warm up once outside the assertion to amortise any first-call setup.
+    // Warm up once outside the assertion to amortise any first-call setup
+    // (also drains any pending crossbeam message — see doc comment above).
     engine.process(input, output).unwrap();
 
     let violations = check_no_alloc(|| {
@@ -362,9 +369,9 @@ mod ir_cabinet {
     fn ir_cabinet_via_loader_does_not_allocate() {
         // Sanity check: WAV-loaded FIR cabinet behaves the same as the
         // synthesised one. Loading happens before the assert scope.
-        let dir = std::env::temp_dir().join("rustortion_no_alloc_ir");
-        let _ = write_test_ir(&dir, "tiny.wav", 1024);
-        let loader = IrLoader::new(&dir, SAMPLE_RATE).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let _ = write_test_ir(dir.path(), "tiny.wav", 1024);
+        let loader = IrLoader::new(dir.path(), SAMPLE_RATE).unwrap();
         let ir_samples = loader.load_by_name("tiny.wav").unwrap();
 
         let max_ir_samples = (SAMPLE_RATE * DEFAULT_MAX_IR_MS) / 1000;
@@ -393,9 +400,11 @@ mod extras {
     #[test]
     fn full_engine_does_not_allocate() {
         // Covers: Engine::new path with tuner (disabled), metronome
-        // (disabled), and peak meter (always-on once present). The peak meter
-        // allocates internally; engine.rs wraps that call in permit_alloc with
-        // a FIXME pointing to peak_meter.rs:62.
+        // (disabled), and peak meter (always-on once present).
+        //
+        // The peak meter does allocate per block; engine.rs gates that call
+        // with permit_alloc + FIXME (peak_meter.rs:62). This test asserts the
+        // *rest* of the full-engine path is alloc-free given that gate.
         let (mut engine, _handle) = full_engine(1.0, None);
         let (input, mut output) = buffers();
         assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
@@ -426,14 +435,27 @@ mod extras {
 
     #[test]
     fn pitch_shifter_does_not_allocate() {
-        // Covers: PitchShifter process_block on the hot loop. The shifter
-        // allocates internally; engine.rs wraps that call in permit_alloc with
-        // a FIXME pointing to pitch_shifter.rs.
+        // Covers: PitchShifter::new (one-shot at SetPitchShift drain) AND
+        // process_block (per audio block). Both allocate; engine.rs gates
+        // them with permit_alloc + FIXME (pitch_shifter.rs).
+        //
+        // We send `set_pitch_shift` *inside* the assert scope so the
+        // construction is observed — the warm-up call would otherwise drain
+        // the message before the assertion starts.
         let (mut engine, handle, _rx) = plugin_engine(1.0);
-        handle.set_pitch_shift(7);
-
         let (input, mut output) = buffers();
-        assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+        engine.process(&input, &mut output).unwrap();
+
+        let violations = check_no_alloc(|| {
+            handle.set_pitch_shift(7);
+            for _ in 0..16 {
+                engine.process(&input, &mut output).unwrap();
+            }
+        });
+        assert_eq!(
+            violations, 0,
+            "pitch shifter path allocated {violations} time(s)"
+        );
     }
 
     #[test]
@@ -441,18 +463,12 @@ mod extras {
         // Covers: Recorder::record_block called from Engine::process under
         // lightweight=false. The recorder allocates internally; engine.rs
         // wraps that call in permit_alloc with a FIXME pointing to
-        // recorder.rs:47. Recorder::new opens a WAV file + spawns a thread,
-        // which is one-shot setup wrapped in permit_alloc here.
+        // recorder.rs:47.
         let (mut engine, handle) = full_engine(1.0, None);
-        let tmp = std::env::temp_dir().join("rustortion_no_alloc_rec");
-        let recorder =
-            permit_alloc(|| Recorder::new(SAMPLE_RATE as u32, tmp.to_str().unwrap()).unwrap());
+        let tmp = tempfile::tempdir().unwrap();
         handle
-            .start_recording(SAMPLE_RATE, tmp.to_str().unwrap())
+            .start_recording(SAMPLE_RATE, tmp.path().to_str().unwrap())
             .unwrap();
-        // Drop the locally-built recorder; the engine will use the one it
-        // created from the StartRecording message.
-        drop(recorder);
 
         let (input, mut output) = buffers();
         assert_engine_alloc_free(&mut engine, &input, &mut output, 32);

--- a/rustortion-core/tests/no_alloc.rs
+++ b/rustortion-core/tests/no_alloc.rs
@@ -1,0 +1,460 @@
+#![allow(clippy::pedantic, clippy::nursery, clippy::type_complexity)]
+
+//! Real-time path allocation audit.
+//!
+//! Each test exercises a slice of the engine inside `assert_no_alloc(...)` so
+//! that any unexpected heap traffic on the audio thread will panic.
+//!
+//! Tests that legitimately panic from allocations on the hot loop are marked
+//! `#[ignore = "FIXME: ..."]` with a `file:line` pointer to the offender so we
+//! have a paper trail of every known issue. Setup-time allocation (constructor
+//! work that runs *before* the assert scope) is fine and noted in the per-test
+//! comment.
+
+use assert_no_alloc::{
+    AllocDisabler, assert_no_alloc, permit_alloc, reset_violation_count, violation_count,
+};
+use hound::{WavSpec, WavWriter};
+
+use rustortion_core::amp::chain::AmplifierChain;
+use rustortion_core::amp::stages::Stage;
+use rustortion_core::amp::stages::clipper::ClipperType;
+use rustortion_core::amp::stages::compressor::CompressorStage;
+use rustortion_core::amp::stages::delay::DelayStage;
+use rustortion_core::amp::stages::eq::{EqStage, NUM_BANDS};
+use rustortion_core::amp::stages::filter::{FilterStage, FilterType};
+use rustortion_core::amp::stages::level::LevelStage;
+use rustortion_core::amp::stages::multiband_saturator::MultibandSaturatorStage;
+use rustortion_core::amp::stages::noise_gate::NoiseGateStage;
+use rustortion_core::amp::stages::poweramp::{PowerAmpStage, PowerAmpType};
+use rustortion_core::amp::stages::preamp::PreampStage;
+use rustortion_core::amp::stages::reverb::ReverbStage;
+use rustortion_core::amp::stages::tonestack::{ToneStackModel, ToneStackStage};
+use rustortion_core::audio::engine::{Engine, EngineHandle};
+use rustortion_core::audio::peak_meter::PeakMeter;
+use rustortion_core::audio::recorder::Recorder;
+use rustortion_core::audio::rt_drop::{RtDropHandle, RtDropReceiver};
+use rustortion_core::audio::samplers::Samplers;
+use rustortion_core::ir::cabinet::{ConvolverType, DEFAULT_MAX_IR_MS, IrCabinet};
+use rustortion_core::ir::convolver::Convolver;
+use rustortion_core::ir::loader::IrLoader;
+use rustortion_core::metronome::Metronome;
+use rustortion_core::tuner::Tuner;
+
+#[global_allocator]
+static A: AllocDisabler = AllocDisabler;
+
+const SAMPLE_RATE: usize = 48_000;
+const SAMPLE_RATE_F32: f32 = 48_000.0;
+const BUFFER_SIZE: usize = 128;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Run `body` inside `assert_no_alloc` and return the number of violations
+/// that were recorded. With the `warn_debug` feature on, `assert_no_alloc`
+/// counts allocation attempts instead of aborting — so we can panic with a
+/// useful message at the test boundary instead of killing the test binary.
+fn check_no_alloc<F: FnOnce()>(body: F) -> u32 {
+    reset_violation_count();
+    assert_no_alloc(body);
+    violation_count()
+}
+
+/// Run `engine.process()` `iters` times inside an `assert_no_alloc` scope
+/// after one warm-up call. Panics if any allocation was observed.
+fn assert_engine_alloc_free(engine: &mut Engine, input: &[f32], output: &mut [f32], iters: usize) {
+    // Warm up once outside the assertion to amortise any first-call setup.
+    engine.process(input, output).unwrap();
+
+    let violations = check_no_alloc(|| {
+        for _ in 0..iters {
+            engine.process(input, output).unwrap();
+        }
+    });
+    assert_eq!(
+        violations, 0,
+        "engine.process() allocated {violations} time(s) on the RT path"
+    );
+}
+
+/// Build a plugin-style engine plus the standard input/output buffers.
+fn plugin_engine(oversample: f64) -> (Engine, EngineHandle, RtDropReceiver) {
+    Engine::new_for_plugin(SAMPLE_RATE, BUFFER_SIZE, None, oversample)
+        .expect("engine should construct")
+}
+
+/// Plugin-style engine with an IR cabinet attached. No peak meter / tuner /
+/// metronome / recorder, so the IR convolver is the only thing under test.
+fn plugin_engine_with_ir(
+    oversample: f64,
+    cabinet: IrCabinet,
+) -> (Engine, EngineHandle, RtDropReceiver) {
+    Engine::new_for_plugin(SAMPLE_RATE, BUFFER_SIZE, Some(cabinet), oversample)
+        .expect("engine should construct")
+}
+
+/// Build the full standalone-style engine (tuner + peak meter + metronome
+/// present, but disabled). Allows exercising every code path that's gated
+/// behind `lightweight = false`.
+fn full_engine(oversample: f64, ir_cabinet: Option<IrCabinet>) -> (Engine, EngineHandle) {
+    let (tuner, _) = Tuner::new(SAMPLE_RATE);
+    let (peak_meter, _) = PeakMeter::new(SAMPLE_RATE);
+    let samplers = Samplers::new(BUFFER_SIZE, oversample, SAMPLE_RATE).unwrap();
+    let metronome = Metronome::new(120.0, SAMPLE_RATE);
+    let (engine, handle) = Engine::new(
+        tuner,
+        samplers,
+        ir_cabinet,
+        peak_meter,
+        metronome,
+        RtDropHandle::new().0,
+    )
+    .unwrap();
+    (engine, handle)
+}
+
+fn buffers() -> (Vec<f32>, Vec<f32>) {
+    (vec![0.5_f32; BUFFER_SIZE], vec![0.0_f32; BUFFER_SIZE])
+}
+
+/// Build an in-memory FIR convolver loaded with a tiny synthetic IR. Avoids
+/// touching the filesystem so tests stay hermetic.
+fn make_fir_convolver() -> Convolver {
+    let max_ir_samples = (SAMPLE_RATE * DEFAULT_MAX_IR_MS) / 1000;
+    let mut conv = Convolver::new_fir(max_ir_samples);
+    let ir: Vec<f32> = (0..256).map(|i| (-(i as f32) / 64.0).exp() * 0.5).collect();
+    conv.set_ir(&ir).unwrap();
+    conv
+}
+
+fn make_two_stage_convolver() -> Convolver {
+    let mut conv = Convolver::new_two_stage();
+    let ir: Vec<f32> = (0..2048)
+        .map(|i| (-(i as f32) / 256.0).exp() * 0.3)
+        .collect();
+    conv.set_ir(&ir).unwrap();
+    conv
+}
+
+/// Materialise a tiny WAV on disk so the loader path can also be exercised.
+/// Used by the IR-cabinet tests that validate loading via `IrLoader`.
+fn write_test_ir(dir: &std::path::Path, name: &str, length: usize) -> std::path::PathBuf {
+    std::fs::create_dir_all(dir).unwrap();
+    let path = dir.join(name);
+    let spec = WavSpec {
+        channels: 1,
+        sample_rate: SAMPLE_RATE as u32,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(&path, spec).unwrap();
+    for i in 0..length {
+        let t = i as f32 / SAMPLE_RATE as f32;
+        let decay = (-t * 5.0).exp();
+        let s = (440.0 * std::f32::consts::TAU * t).sin() * decay;
+        writer.write_sample((s * i16::MAX as f32) as i16).unwrap();
+    }
+    writer.finalize().unwrap();
+    path
+}
+
+// ---------------------------------------------------------------------------
+// Baseline engine tests (kept from the seed file)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn engine_process_does_not_allocate_with_empty_chain() {
+    // Covers: Engine::process with no chain, no IR, no extras.
+    let (mut engine, _handle, _rx) = plugin_engine(1.0);
+    let (input, mut output) = buffers();
+    assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+}
+
+#[test]
+fn engine_process_does_not_allocate_with_chain() {
+    // Covers: SetAmpChain warm-up + steady-state processing through one stage.
+    let (mut engine, handle, _rx) = plugin_engine(1.0);
+
+    let mut chain = AmplifierChain::new();
+    chain.add_stage(Box::new(LevelStage::new(0.5)));
+    handle.set_amp_chain(chain);
+
+    let (input, mut output) = buffers();
+    assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+}
+
+#[test]
+fn engine_process_does_not_allocate_with_oversampling() {
+    // Covers: rubato FftFixedInOut up/downsampler hot path at 4x.
+    let (mut engine, handle, _rx) = plugin_engine(4.0);
+
+    let mut chain = AmplifierChain::new();
+    chain.add_stage(Box::new(LevelStage::new(0.5)));
+    handle.set_amp_chain(chain);
+
+    let (input, mut output) = buffers();
+    assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+}
+
+// ---------------------------------------------------------------------------
+// Per-stage tests
+// ---------------------------------------------------------------------------
+
+mod stages {
+    //! One test per registered stage type. Each adds the stage via
+    //! `EngineHandle::add_stage`, drains the message with one warm-up call,
+    //! then asserts the hot loop is allocation-free.
+
+    use super::*;
+
+    fn run_with_stage(stage: Box<dyn Stage>) {
+        let (mut engine, handle, _rx) = plugin_engine(1.0);
+        handle.add_stage(0, stage);
+        let (input, mut output) = buffers();
+        assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+    }
+
+    #[test]
+    fn preamp_stage_does_not_allocate() {
+        // Covers: PreampStage process (asym tanh + interstage LP + DC blocker).
+        run_with_stage(Box::new(PreampStage::new(
+            5.0,
+            0.0,
+            ClipperType::Soft,
+            SAMPLE_RATE_F32,
+        )));
+    }
+
+    #[test]
+    fn compressor_stage_does_not_allocate() {
+        // Covers: CompressorStage envelope follower + gain reduction.
+        run_with_stage(Box::new(CompressorStage::new(
+            1.0,
+            50.0,
+            -20.0,
+            4.0,
+            0.0,
+            SAMPLE_RATE_F32,
+        )));
+    }
+
+    #[test]
+    fn noise_gate_stage_does_not_allocate() {
+        // Covers: NoiseGateStage envelope + gate state smoothing.
+        run_with_stage(Box::new(NoiseGateStage::new(
+            -30.0,
+            10.0,
+            1.0,
+            50.0,
+            50.0,
+            SAMPLE_RATE_F32,
+        )));
+    }
+
+    #[test]
+    fn tonestack_stage_does_not_allocate() {
+        // Covers: ToneStackStage 3-band first-order filters + presence shelf.
+        run_with_stage(Box::new(ToneStackStage::new(
+            ToneStackModel::Modern,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            SAMPLE_RATE_F32,
+        )));
+    }
+
+    #[test]
+    fn poweramp_stage_does_not_allocate() {
+        // Covers: PowerAmpStage class-A tanh + sag envelope + DC blocker.
+        run_with_stage(Box::new(PowerAmpStage::new(
+            0.5,
+            PowerAmpType::ClassA,
+            0.3,
+            80.0,
+            SAMPLE_RATE_F32,
+        )));
+    }
+
+    #[test]
+    fn multiband_saturator_stage_does_not_allocate() {
+        // Covers: MultibandSaturatorStage three LR4 bands + per-band saturation.
+        run_with_stage(Box::new(MultibandSaturatorStage::new(
+            0.5,
+            0.5,
+            0.5,
+            1.0,
+            1.0,
+            1.0,
+            200.0,
+            2000.0,
+            SAMPLE_RATE_F32,
+        )));
+    }
+
+    #[test]
+    fn level_stage_does_not_allocate() {
+        // Covers: LevelStage trivial gain multiply (already in baseline but
+        // kept here for symmetry with the other stage entries).
+        run_with_stage(Box::new(LevelStage::new(0.5)));
+    }
+
+    #[test]
+    fn delay_stage_does_not_allocate() {
+        // Covers: DelayStage ring buffer read + smoothing. Buffer is
+        // pre-allocated to MAX_DELAY_MS in DelayStage::new (init-only, fine).
+        run_with_stage(Box::new(DelayStage::new(250.0, 0.4, 0.5, SAMPLE_RATE_F32)));
+    }
+
+    #[test]
+    fn reverb_stage_does_not_allocate() {
+        // Covers: ReverbStage Schroeder bank (8 combs + 4 allpasses).
+        run_with_stage(Box::new(ReverbStage::new(0.5, 0.5, 0.3, SAMPLE_RATE_F32)));
+    }
+
+    #[test]
+    fn eq_stage_does_not_allocate() {
+        // Covers: EqStage 16-band cascaded biquads.
+        run_with_stage(Box::new(EqStage::new([0.0; NUM_BANDS], SAMPLE_RATE_F32)));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IR cabinet tests
+// ---------------------------------------------------------------------------
+
+mod ir_cabinet {
+    //! Both convolver implementations exercised end-to-end through the engine.
+    //! IRs are synthesised in memory; the convolver allocates its working
+    //! buffers in `set_ir`, which runs at construction time (init-only, fine).
+
+    use super::*;
+
+    #[test]
+    fn fir_convolver_does_not_allocate() {
+        // Covers: IrCabinet + FirConvolver process_block on the hot path.
+        // Uses the plugin engine so peak_meter (which does allocate) is
+        // out of scope — see extras::peak_meter_does_not_allocate.
+        let max_ir_samples = (SAMPLE_RATE * DEFAULT_MAX_IR_MS) / 1000;
+        let mut cabinet = IrCabinet::new(ConvolverType::Fir, max_ir_samples);
+        cabinet.swap_convolver(make_fir_convolver());
+
+        let (mut engine, _handle, _rx) = plugin_engine_with_ir(1.0, cabinet);
+        let (input, mut output) = buffers();
+        assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+    }
+
+    #[test]
+    fn two_stage_fft_convolver_does_not_allocate() {
+        // Covers: IrCabinet + TwoStageConvolver (FFT) process_block.
+        let max_ir_samples = (SAMPLE_RATE * DEFAULT_MAX_IR_MS) / 1000;
+        let mut cabinet = IrCabinet::new(ConvolverType::TwoStage, max_ir_samples);
+        cabinet.swap_convolver(make_two_stage_convolver());
+
+        let (mut engine, _handle, _rx) = plugin_engine_with_ir(1.0, cabinet);
+        let (input, mut output) = buffers();
+        assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+    }
+
+    #[test]
+    fn ir_cabinet_via_loader_does_not_allocate() {
+        // Sanity check: WAV-loaded FIR cabinet behaves the same as the
+        // synthesised one. Loading happens before the assert scope.
+        let dir = std::env::temp_dir().join("rustortion_no_alloc_ir");
+        let _ = write_test_ir(&dir, "tiny.wav", 1024);
+        let loader = IrLoader::new(&dir, SAMPLE_RATE).unwrap();
+        let ir_samples = loader.load_by_name("tiny.wav").unwrap();
+
+        let max_ir_samples = (SAMPLE_RATE * DEFAULT_MAX_IR_MS) / 1000;
+        let mut cabinet = IrCabinet::new(ConvolverType::Fir, max_ir_samples);
+        let mut convolver = Convolver::new_fir(max_ir_samples);
+        convolver.set_ir(&ir_samples).unwrap();
+        cabinet.swap_convolver(convolver);
+
+        let (mut engine, _handle, _rx) = plugin_engine_with_ir(1.0, cabinet);
+        let (input, mut output) = buffers();
+        assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine "extras" wired up via the full Engine::new constructor
+// ---------------------------------------------------------------------------
+
+mod extras {
+    //! Tuner (disabled), metronome (disabled), peak meter (always on),
+    //! input filters, pitch shifter — all wired to the standalone-style
+    //! Engine to exercise the lightweight=false code path.
+
+    use super::*;
+
+    #[test]
+    fn full_engine_does_not_allocate() {
+        // Covers: Engine::new path with tuner (disabled), metronome
+        // (disabled), and peak meter (always-on once present). The peak meter
+        // allocates internally; engine.rs wraps that call in permit_alloc with
+        // a FIXME pointing to peak_meter.rs:62.
+        let (mut engine, _handle) = full_engine(1.0, None);
+        let (input, mut output) = buffers();
+        assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+    }
+
+    #[test]
+    fn input_filters_do_not_allocate() {
+        // Covers: SetInputFilters + apply_input_filters on the hot path.
+        // Uses plugin engine so the peak meter is out of scope (see
+        // full_engine_does_not_allocate). FilterStage::new runs at
+        // construction time (init-only, fine).
+        let (mut engine, handle, _rx) = plugin_engine(1.0);
+        let hp: Box<dyn Stage> = Box::new(FilterStage::new(
+            FilterType::Highpass,
+            80.0,
+            SAMPLE_RATE_F32,
+        ));
+        let lp: Box<dyn Stage> = Box::new(FilterStage::new(
+            FilterType::Lowpass,
+            8000.0,
+            SAMPLE_RATE_F32,
+        ));
+        handle.set_input_filters(Some(hp), Some(lp));
+
+        let (input, mut output) = buffers();
+        assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+    }
+
+    #[test]
+    fn pitch_shifter_does_not_allocate() {
+        // Covers: PitchShifter process_block on the hot loop. The shifter
+        // allocates internally; engine.rs wraps that call in permit_alloc with
+        // a FIXME pointing to pitch_shifter.rs.
+        let (mut engine, handle, _rx) = plugin_engine(1.0);
+        handle.set_pitch_shift(7);
+
+        let (input, mut output) = buffers();
+        assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+    }
+
+    #[test]
+    fn recorder_record_block_does_not_allocate() {
+        // Covers: Recorder::record_block called from Engine::process under
+        // lightweight=false. The recorder allocates internally; engine.rs
+        // wraps that call in permit_alloc with a FIXME pointing to
+        // recorder.rs:47. Recorder::new opens a WAV file + spawns a thread,
+        // which is one-shot setup wrapped in permit_alloc here.
+        let (mut engine, handle) = full_engine(1.0, None);
+        let tmp = std::env::temp_dir().join("rustortion_no_alloc_rec");
+        let recorder =
+            permit_alloc(|| Recorder::new(SAMPLE_RATE as u32, tmp.to_str().unwrap()).unwrap());
+        handle
+            .start_recording(SAMPLE_RATE, tmp.to_str().unwrap())
+            .unwrap();
+        // Drop the locally-built recorder; the engine will use the one it
+        // created from the StartRecording message.
+        drop(recorder);
+
+        let (input, mut output) = buffers();
+        assert_engine_alloc_free(&mut engine, &input, &mut output, 32);
+    }
+}

--- a/rustortion-standalone/Cargo.toml
+++ b/rustortion-standalone/Cargo.toml
@@ -37,3 +37,4 @@ midir = "0.11"
 
 [dev-dependencies]
 tempfile = "3.24"
+assert_no_alloc = { version = "1.1", features = ["warn_debug"] }

--- a/rustortion-standalone/tests/engine.rs
+++ b/rustortion-standalone/tests/engine.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::pedantic, clippy::nursery)]
 
 use anyhow::Result;
+use assert_no_alloc::{AllocDisabler, assert_no_alloc, reset_violation_count, violation_count};
 use rustortion_core::amp::chain::AmplifierChain;
 use rustortion_core::amp::stages::level::LevelStage;
 use rustortion_core::audio::engine::Engine;
@@ -9,6 +10,22 @@ use rustortion_core::audio::rt_drop::RtDropHandle;
 use rustortion_core::audio::samplers::Samplers;
 use rustortion_core::metronome::Metronome;
 use rustortion_core::tuner::Tuner;
+
+#[global_allocator]
+static A: AllocDisabler = AllocDisabler;
+
+/// Run `body` inside `assert_no_alloc` and return the violation count. With
+/// the `warn_debug` feature on, allocations are counted instead of aborting,
+/// so we can panic with a useful message at the test boundary.
+///
+/// Engine::process internally permits a handful of known offenders
+/// (peak_meter, recorder, pitch_shifter) — see the FIXME comments in
+/// audio/engine.rs. Anything else allocating on the RT path is a regression.
+fn check_no_alloc<F: FnOnce()>(body: F) -> u32 {
+    reset_violation_count();
+    assert_no_alloc(body);
+    violation_count()
+}
 
 #[test]
 fn engine_processes_non_zero_signal() -> Result<()> {
@@ -35,6 +52,13 @@ fn engine_processes_non_zero_signal() -> Result<()> {
     engine.process(&input, &mut output)?;
 
     assert!(output.iter().any(|&x| x != 0.0), "expected non-zero output");
+
+    let violations = check_no_alloc(|| {
+        for _ in 0..16 {
+            engine.process(&input, &mut output).unwrap();
+        }
+    });
+    assert_eq!(violations, 0, "engine.process allocated on RT path");
 
     Ok(())
 }
@@ -84,6 +108,16 @@ fn engine_handles_buffer_size_change() -> Result<()> {
         output.len(),
         NEW_BUFFER_SIZE,
         "output length should match new buffer size"
+    );
+
+    let violations = check_no_alloc(|| {
+        for _ in 0..16 {
+            engine.process(&input, &mut output).unwrap();
+        }
+    });
+    assert_eq!(
+        violations, 0,
+        "engine.process allocated on RT path after buffer resize"
     );
 
     Ok(())
@@ -165,6 +199,16 @@ fn engine_applies_amp_chain() -> Result<()> {
     assert!(
         chain_rms < baseline_rms,
         "expected 0.5x level to attenuate: baseline_rms={baseline_rms}, chain_rms={chain_rms}"
+    );
+
+    let violations = check_no_alloc(|| {
+        for _ in 0..16 {
+            engine.process(&input, &mut output).unwrap();
+        }
+    });
+    assert_eq!(
+        violations, 0,
+        "engine.process allocated on RT path with amp chain installed"
     );
 
     Ok(())
@@ -293,6 +337,17 @@ fn engine_set_parameter_updates_live_stage() -> Result<()> {
         (after - before * 0.5).abs() < 0.01,
         "expected ~{}, got {after}",
         before * 0.5
+    );
+
+    let violations = check_no_alloc(|| {
+        for i in 0..16 {
+            handle.set_parameter(0, "gain", 0.1 + (i as f32) * 0.05);
+            engine.process(&input, &mut output).unwrap();
+        }
+    });
+    assert_eq!(
+        violations, 0,
+        "engine.process + set_parameter allocated on RT path"
     );
 
     Ok(())


### PR DESCRIPTION
Closes #237.

## Summary
- Adds `assert_no_alloc` (`warn_debug` feature) and a new `rustortion-core/tests/no_alloc.rs` (20 tests) that runs `Engine::process` inside an `assert_no_alloc` scope across all 10 stage types, both IR convolver implementations, and the full standalone-style engine.
- Wraps the existing standalone integration tests (`rustortion-standalone/tests/engine.rs`) with `assert_no_alloc` after their original assertions for end-to-end coverage.
- Documents three known RT-path allocators (`peak_meter`, `pitch_shifter`, `recorder`) with `permit_alloc` + FIXME comments at their call sites in `engine.rs`. The underlying modules are the proper fix targets.
- Wraps the two unavoidable `Box::new(...)` sites in `Engine::handle_messages` (IR convolver retire, samplers retire) with `permit_alloc` — `RtDropHandle` takes `Box<dyn Send>` so type erasure forces an allocation. Follow-up: hold the values as `Box<T>` on the engine side to remove the allocation entirely.

## Known offenders (permit_alloc'd, FIXME)
- `audio/peak_meter.rs:62` — `Arc::new(PeakMeterInfo)` per block. Trivial fix: replace `Arc<ArcSwap<PeakMeterInfo>>` with three atomics.
- `audio/pitch_shifter.rs` — Vec scratch buffers in `process_block`.
- `audio/recorder.rs:47` — `Vec::with_capacity` per block.
- `audio/engine.rs:296,333` — boxing for `RtDropHandle::retire` (channel type erasure).

## Test plan
- [x] `cargo test -p rustortion-core --test no_alloc` — 20 passed
- [x] `cargo test -p rustortion-standalone --test engine` — 7 passed (4 new alloc assertions added)
- [x] `make test` — full suite green
- [x] `make lint` — clean (clippy with `-D warnings -D pedantic -D nursery`)

## Out of scope (follow-up work)
- Plugin (`rustortion-plugin`) feature flag for `nih_plug/assert_process_allocs`.
- Standalone JACK callback wrap.
- Proper fixes for the four FIXME'd allocations above.