### PR TITLE
chore(deps): upgrade rubato to 3.0 and refresh dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.1",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "android-build"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cac4c64175d504608cf239756339c07f6384a476f97f20a7043f92920b0b8fd"
+checksum = "f9fc9904ad2ad097c3c1cfe2eacaaf0fc24710936fa9ed941cb310b7c6ed2ab7"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -400,10 +400,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
+name = "audio-core"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -522,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -643,9 +680,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1134,7 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1246,9 +1283,9 @@ checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "endi"
@@ -1806,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2091,7 +2128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2155,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -2168,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2277,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2369,14 +2406,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.8.0",
 ]
 
 [[package]]
@@ -2423,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
@@ -2444,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -2528,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "mundy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523813c9e194ec43693805214eb112551f99382115b67f38600d724a692e7e8b"
+checksum = "f32eb0db40f2df2bcfb05c93b8f73938d4c26ce9ac8881f1df0c8d3296921a73"
 dependencies = [
  "android-build",
  "async-io",
@@ -2538,7 +2575,7 @@ dependencies = [
  "dispatch",
  "futures-channel",
  "futures-lite",
- "jni 0.21.1",
+ "jni 0.22.4",
  "ndk-context",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -2689,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -2710,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3158,9 +3195,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c6933ddbbd16539a7672e697bb8d41ac3a4e99ac43eeb40c07236bd7fcb2dd"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
  "libc",
  "libredox",
@@ -3247,18 +3284,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3400,7 +3437,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -3414,15 +3451,15 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -3542,9 +3579,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -3612,14 +3649,18 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rubato"
-version = "0.16.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5258099699851cfd0082aeb645feb9c084d9a5e1f1b8d5372086b989fc5e56a1"
+checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
 dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
  "num-complex",
  "num-integer",
  "num-traits",
  "realfft",
+ "visibility",
+ "windowfunctions",
 ]
 
 [[package]]
@@ -3908,9 +3949,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3952,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4367,9 +4408,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "pin-project-lite",
 ]
@@ -4419,14 +4460,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4435,7 +4476,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4491,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -4565,9 +4606,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -4579,6 +4620,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "vst3-com"
@@ -4653,9 +4705,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4666,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4676,9 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4686,9 +4738,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4699,9 +4751,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4891,9 +4943,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5123,6 +5175,15 @@ dependencies = [
  "clipboard_x11",
  "raw-window-handle 0.6.2",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -5528,9 +5589,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -5718,9 +5779,9 @@ checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "zbus"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -5743,9 +5804,9 @@ dependencies = [
  "serde_repr",
  "tracing",
  "uds_windows",
- "uuid 1.23.1",
+ "uuid 1.23.2",
  "windows-sys 0.61.2",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -5753,9 +5814,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5773,7 +5834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant",
 ]
 
@@ -5785,18 +5846,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5811,23 +5872,23 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "5.10.1"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.1"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5838,13 +5899,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]

--- a/rustortion-core/Cargo.toml
+++ b/rustortion-core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 clap = { version = "4.5", features = ["derive"] }
 hound = "3.5"
 chrono = "0.4"
-rubato = "0.16"
+rubato = "3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 crossbeam = "0.8"

--- a/rustortion-core/benches/samplers.rs
+++ b/rustortion-core/benches/samplers.rs
@@ -3,9 +3,10 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
 
+use rubato::audioadapter_buffers::direct::SequentialSliceOfVecs;
 use rubato::{
-    FastFixedIn, FftFixedIn, FftFixedOut, PolynomialDegree, Resampler, SincFixedIn,
-    SincInterpolationParameters, SincInterpolationType, WindowFunction,
+    Async, Fft, FixedAsync, FixedSync, PolynomialDegree, Resampler, SincInterpolationParameters,
+    SincInterpolationType, WindowFunction,
 };
 
 const SAMPLE_RATE: usize = 48000;
@@ -27,22 +28,14 @@ fn generate_test_signal(size: usize) -> Vec<Vec<f32>> {
 // Resampler Pairs
 // ============================================================================
 
-struct SincPair {
-    up: SincFixedIn<f32>,
-    down: SincFixedIn<f32>,
+struct ResamplerPair {
+    up: Box<dyn Resampler<f32>>,
+    down: Box<dyn Resampler<f32>>,
 }
 
-struct FastPair {
-    up: FastFixedIn<f32>,
-    down: FastFixedIn<f32>,
-}
+type PairFactory = fn(usize) -> ResamplerPair;
 
-struct FftPair {
-    up: FftFixedIn<f32>,
-    down: FftFixedOut<f32>,
-}
-
-fn create_sinc_current(factor: usize) -> SincPair {
+fn create_sinc_current(factor: usize) -> ResamplerPair {
     let up_params = SincInterpolationParameters {
         sinc_len: 128,
         f_cutoff: 0.95,
@@ -58,20 +51,33 @@ fn create_sinc_current(factor: usize) -> SincPair {
         window: WindowFunction::BlackmanHarris2,
     };
 
-    SincPair {
-        up: SincFixedIn::new(factor as f64, 1.0, up_params, BUFFER_SIZE, CHANNELS).unwrap(),
-        down: SincFixedIn::new(
-            1.0 / factor as f64,
-            1.0,
-            down_params,
-            BUFFER_SIZE * factor,
-            CHANNELS,
-        )
-        .unwrap(),
+    ResamplerPair {
+        up: Box::new(
+            Async::<f32>::new_sinc(
+                factor as f64,
+                1.0,
+                &up_params,
+                BUFFER_SIZE,
+                CHANNELS,
+                FixedAsync::Input,
+            )
+            .unwrap(),
+        ),
+        down: Box::new(
+            Async::<f32>::new_sinc(
+                1.0 / factor as f64,
+                1.0,
+                &down_params,
+                BUFFER_SIZE * factor,
+                CHANNELS,
+                FixedAsync::Input,
+            )
+            .unwrap(),
+        ),
     }
 }
 
-fn create_sinc_veryfast(factor: usize) -> SincPair {
+fn create_sinc_veryfast(factor: usize) -> ResamplerPair {
     let up_params = SincInterpolationParameters {
         sinc_len: 64,
         f_cutoff: 0.91,
@@ -87,79 +93,110 @@ fn create_sinc_veryfast(factor: usize) -> SincPair {
         window: WindowFunction::Hann2,
     };
 
-    SincPair {
-        up: SincFixedIn::new(factor as f64, 1.0, up_params, BUFFER_SIZE, CHANNELS).unwrap(),
-        down: SincFixedIn::new(
-            1.0 / factor as f64,
-            1.0,
-            down_params,
-            BUFFER_SIZE * factor,
-            CHANNELS,
-        )
-        .unwrap(),
+    ResamplerPair {
+        up: Box::new(
+            Async::<f32>::new_sinc(
+                factor as f64,
+                1.0,
+                &up_params,
+                BUFFER_SIZE,
+                CHANNELS,
+                FixedAsync::Input,
+            )
+            .unwrap(),
+        ),
+        down: Box::new(
+            Async::<f32>::new_sinc(
+                1.0 / factor as f64,
+                1.0,
+                &down_params,
+                BUFFER_SIZE * factor,
+                CHANNELS,
+                FixedAsync::Input,
+            )
+            .unwrap(),
+        ),
     }
 }
 
-fn create_fast_cubic(factor: usize) -> FastPair {
-    FastPair {
-        up: FastFixedIn::new(
-            factor as f64,
-            1.0,
-            PolynomialDegree::Cubic,
-            BUFFER_SIZE,
-            CHANNELS,
-        )
-        .unwrap(),
-        down: FastFixedIn::new(
-            1.0 / factor as f64,
-            1.0,
-            PolynomialDegree::Cubic,
-            BUFFER_SIZE * factor,
-            CHANNELS,
-        )
-        .unwrap(),
+fn create_fast_cubic(factor: usize) -> ResamplerPair {
+    ResamplerPair {
+        up: Box::new(
+            Async::<f32>::new_poly(
+                factor as f64,
+                1.0,
+                PolynomialDegree::Cubic,
+                BUFFER_SIZE,
+                CHANNELS,
+                FixedAsync::Input,
+            )
+            .unwrap(),
+        ),
+        down: Box::new(
+            Async::<f32>::new_poly(
+                1.0 / factor as f64,
+                1.0,
+                PolynomialDegree::Cubic,
+                BUFFER_SIZE * factor,
+                CHANNELS,
+                FixedAsync::Input,
+            )
+            .unwrap(),
+        ),
     }
 }
 
-fn create_fast_linear(factor: usize) -> FastPair {
-    FastPair {
-        up: FastFixedIn::new(
-            factor as f64,
-            1.0,
-            PolynomialDegree::Linear,
-            BUFFER_SIZE,
-            CHANNELS,
-        )
-        .unwrap(),
-        down: FastFixedIn::new(
-            1.0 / factor as f64,
-            1.0,
-            PolynomialDegree::Linear,
-            BUFFER_SIZE * factor,
-            CHANNELS,
-        )
-        .unwrap(),
+fn create_fast_linear(factor: usize) -> ResamplerPair {
+    ResamplerPair {
+        up: Box::new(
+            Async::<f32>::new_poly(
+                factor as f64,
+                1.0,
+                PolynomialDegree::Linear,
+                BUFFER_SIZE,
+                CHANNELS,
+                FixedAsync::Input,
+            )
+            .unwrap(),
+        ),
+        down: Box::new(
+            Async::<f32>::new_poly(
+                1.0 / factor as f64,
+                1.0,
+                PolynomialDegree::Linear,
+                BUFFER_SIZE * factor,
+                CHANNELS,
+                FixedAsync::Input,
+            )
+            .unwrap(),
+        ),
     }
 }
 
-fn create_fft(factor: usize) -> FftPair {
-    FftPair {
-        up: FftFixedIn::new(
-            SAMPLE_RATE,
-            SAMPLE_RATE * factor,
-            BUFFER_SIZE,
-            SUB_CHUNKS,
-            CHANNELS,
-        )
-        .unwrap(),
-        down: FftFixedOut::new(
-            SAMPLE_RATE * factor,
-            SAMPLE_RATE,
-            BUFFER_SIZE,
-            SUB_CHUNKS,
-            CHANNELS,
-        )
-        .unwrap(),
+fn create_fft(factor: usize) -> ResamplerPair {
+    ResamplerPair {
+        up: Box::new(
+            Fft::<f32>::new(
+                SAMPLE_RATE,
+                SAMPLE_RATE * factor,
+                BUFFER_SIZE,
+                SUB_CHUNKS,
+                CHANNELS,
+                FixedSync::Input,
+            )
+            .unwrap(),
+        ),
+        down: Box::new(
+            Fft::<f32>::new(
+                SAMPLE_RATE * factor,
+                SAMPLE_RATE,
+                BUFFER_SIZE,
+                SUB_CHUNKS,
+                CHANNELS,
+                FixedSync::Output,
+            )
+            .unwrap(),
+        ),
     }
 }
 
@@ -167,112 +204,55 @@ fn create_fft(factor: usize) -> FftPair {
 // Benchmarks
 // ============================================================================
 
+fn run_roundtrip(pair: &mut ResamplerPair, input: &[Vec<f32>]) {
+    let in_frames = input[0].len();
+    let up_cap = pair.up.output_frames_max();
+    let down_cap = pair.down.output_frames_max();
+
+    let mut up_buf = vec![vec![0.0f32; up_cap]; CHANNELS];
+    let mut down_buf = vec![vec![0.0f32; down_cap]; CHANNELS];
+
+    let in_adapter = SequentialSliceOfVecs::new(black_box(input), CHANNELS, in_frames).unwrap();
+    let mut up_adapter = SequentialSliceOfVecs::new_mut(&mut up_buf, CHANNELS, up_cap).unwrap();
+    pair.up
+        .process_into_buffer(&in_adapter, &mut up_adapter, None)
+        .unwrap();
+
+    let up_in = SequentialSliceOfVecs::new(&up_buf, CHANNELS, up_cap).unwrap();
+    let mut down_adapter =
+        SequentialSliceOfVecs::new_mut(&mut down_buf, CHANNELS, down_cap).unwrap();
+    pair.down
+        .process_into_buffer(&up_in, &mut down_adapter, None)
+        .unwrap();
+
+    black_box(&down_buf);
+}
+
 fn bench_resampler_roundtrip(c: &mut Criterion) {
     let mut group = c.benchmark_group("Resampler Roundtrip");
     group.throughput(Throughput::Elements(BUFFER_SIZE as u64));
 
+    let variants: &[(&str, PairFactory)] = &[
+        ("SincFixedIn-Current", create_sinc_current),
+        ("SincFixedIn-VeryFast", create_sinc_veryfast),
+        ("FastFixedIn-Cubic", create_fast_cubic),
+        ("FastFixedIn-Linear", create_fast_linear),
+        ("FftFixed", create_fft),
+    ];
+
     for &factor in &[2usize, 4, 8] {
         let input = generate_test_signal(BUFFER_SIZE);
 
-        group.bench_with_input(
-            BenchmarkId::new("SincFixedIn-Current", format!("{factor}x")),
-            &factor,
-            |b, &factor| {
-                let mut pair = create_sinc_current(factor);
-                let mut up_buf = pair.up.output_buffer_allocate(true);
-                let mut down_buf = pair.down.output_buffer_allocate(true);
-
-                b.iter(|| {
-                    pair.up
-                        .process_into_buffer(black_box(&input), &mut up_buf, None)
-                        .unwrap();
-                    pair.down
-                        .process_into_buffer(black_box(&up_buf), &mut down_buf, None)
-                        .unwrap();
-                    black_box(&down_buf);
-                });
-            },
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("SincFixedIn-VeryFast", format!("{factor}x")),
-            &factor,
-            |b, &factor| {
-                let mut pair = create_sinc_veryfast(factor);
-                let mut up_buf = pair.up.output_buffer_allocate(true);
-                let mut down_buf = pair.down.output_buffer_allocate(true);
-
-                b.iter(|| {
-                    pair.up
-                        .process_into_buffer(black_box(&input), &mut up_buf, None)
-                        .unwrap();
-                    pair.down
-                        .process_into_buffer(black_box(&up_buf), &mut down_buf, None)
-                        .unwrap();
-                    black_box(&down_buf);
-                });
-            },
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("FastFixedIn-Cubic", format!("{factor}x")),
-            &factor,
-            |b, &factor| {
-                let mut pair = create_fast_cubic(factor);
-                let mut up_buf = pair.up.output_buffer_allocate(true);
-                let mut down_buf = pair.down.output_buffer_allocate(true);
-
-                b.iter(|| {
-                    pair.up
-                        .process_into_buffer(black_box(&input), &mut up_buf, None)
-                        .unwrap();
-                    pair.down
-                        .process_into_buffer(black_box(&up_buf), &mut down_buf, None)
-                        .unwrap();
-                    black_box(&down_buf);
-                });
-            },
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("FastFixedIn-Linear", format!("{factor}x")),
-            &factor,
-            |b, &factor| {
-                let mut pair = create_fast_linear(factor);
-                let mut up_buf = pair.up.output_buffer_allocate(true);
-                let mut down_buf = pair.down.output_buffer_allocate(true);
-
-                b.iter(|| {
-                    pair.up
-                        .process_into_buffer(black_box(&input), &mut up_buf, None)
-                        .unwrap();
-                    pair.down
-                        .process_into_buffer(black_box(&up_buf), &mut down_buf, None)
-                        .unwrap();
-                    black_box(&down_buf);
-                });
-            },
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("FftFixed", format!("{factor}x")),
-            &factor,
-            |b, &factor| {
-                let mut pair = create_fft(factor);
-                let mut up_buf = pair.up.output_buffer_allocate(true);
-                let mut down_buf = pair.down.output_buffer_allocate(true);
-
-                b.iter(|| {
-                    pair.up
-                        .process_into_buffer(black_box(&input), &mut up_buf, None)
-                        .unwrap();
-                    pair.down
-                        .process_into_buffer(black_box(&up_buf), &mut down_buf, None)
-                        .unwrap();
-                    black_box(&down_buf);
-                });
-            },
-        );
+        for &(name, create) in variants {
+            group.bench_with_input(
+                BenchmarkId::new(name, format!("{factor}x")),
+                &factor,
+                |b, &factor| {
+                    let mut pair = create(factor);
+                    b.iter(|| run_roundtrip(&mut pair, &input));
+                },
+            );
+        }
     }
 
     group.finish();

--- a/rustortion-core/benches/samplers.rs
+++ b/rustortion-core/benches/samplers.rs
@@ -204,23 +204,27 @@ fn create_fft(factor: usize) -> ResamplerPair {
 // Benchmarks
 // ============================================================================
 
-fn run_roundtrip(pair: &mut ResamplerPair, input: &[Vec<f32>]) {
+/// Run one up/downsample round trip. The output buffers are passed in and
+/// reused so this hot path only times `process_into_buffer` plus the cheap
+/// (allocation-free) adapter wrapping — never per-iteration heap allocation.
+fn run_roundtrip(
+    pair: &mut ResamplerPair,
+    input: &[Vec<f32>],
+    up_buf: &mut [Vec<f32>],
+    down_buf: &mut [Vec<f32>],
+) {
     let in_frames = input[0].len();
-    let up_cap = pair.up.output_frames_max();
-    let down_cap = pair.down.output_frames_max();
-
-    let mut up_buf = vec![vec![0.0f32; up_cap]; CHANNELS];
-    let mut down_buf = vec![vec![0.0f32; down_cap]; CHANNELS];
+    let up_cap = up_buf[0].len();
+    let down_cap = down_buf[0].len();
 
     let in_adapter = SequentialSliceOfVecs::new(black_box(input), CHANNELS, in_frames).unwrap();
-    let mut up_adapter = SequentialSliceOfVecs::new_mut(&mut up_buf, CHANNELS, up_cap).unwrap();
+    let mut up_adapter = SequentialSliceOfVecs::new_mut(up_buf, CHANNELS, up_cap).unwrap();
     pair.up
         .process_into_buffer(&in_adapter, &mut up_adapter, None)
         .unwrap();
 
-    let up_in = SequentialSliceOfVecs::new(&up_buf, CHANNELS, up_cap).unwrap();
-    let mut down_adapter =
-        SequentialSliceOfVecs::new_mut(&mut down_buf, CHANNELS, down_cap).unwrap();
+    let up_in = SequentialSliceOfVecs::new(&*up_buf, CHANNELS, up_cap).unwrap();
+    let mut down_adapter = SequentialSliceOfVecs::new_mut(down_buf, CHANNELS, down_cap).unwrap();
     pair.down
         .process_into_buffer(&up_in, &mut down_adapter, None)
         .unwrap();
@@ -249,7 +253,9 @@ fn bench_resampler_roundtrip(c: &mut Criterion) {
                 &factor,
                 |b, &factor| {
                     let mut pair = create(factor);
-                    b.iter(|| run_roundtrip(&mut pair, &input));
+                    let mut up_buf = vec![vec![0.0f32; pair.up.output_frames_max()]; CHANNELS];
+                    let mut down_buf = vec![vec![0.0f32; pair.down.output_frames_max()]; CHANNELS];
+                    b.iter(|| run_roundtrip(&mut pair, &input, &mut up_buf, &mut down_buf));
                 },
             );
         }

--- a/rustortion-core/src/amp/stages/multiband_saturator.rs
+++ b/rustortion-core/src/amp/stages/multiband_saturator.rs
@@ -480,8 +480,8 @@ mod tests {
             let output = stage.process(input);
 
             if i >= settle {
-                input_rms_sum += (input as f64) * (input as f64);
-                output_rms_sum += (output as f64) * (output as f64);
+                input_rms_sum = (input as f64).mul_add(input as f64, input_rms_sum);
+                output_rms_sum = (output as f64).mul_add(output as f64, output_rms_sum);
                 measurement_samples += 1;
             }
         }

--- a/rustortion-core/src/amp/stages/preamp.rs
+++ b/rustortion-core/src/amp/stages/preamp.rs
@@ -142,8 +142,8 @@ mod tests {
             for i in 0..n {
                 let input = (i as f32 * 0.1).sin() * 0.3;
                 let out = stage.process(input);
-                sum_in2 += input * input;
-                sum_diff2 += (out - input) * (out - input);
+                sum_in2 = input.mul_add(input, sum_in2);
+                sum_diff2 = (out - input).mul_add(out - input, sum_diff2);
             }
             let in_rms = (sum_in2 / n as f32).sqrt();
             if in_rms < 1e-10 {

--- a/rustortion-core/src/amp/stages/tonestack.rs
+++ b/rustortion-core/src/amp/stages/tonestack.rs
@@ -74,7 +74,7 @@ impl ToneStackStage {
 
     #[inline]
     fn one_pole_lp(alpha: f32, state: &mut f32, x: f32) -> f32 {
-        *state += alpha * (x - *state);
+        *state = alpha.mul_add(x - *state, *state);
         *state
     }
 
@@ -134,7 +134,7 @@ impl Stage for ToneStackStage {
         // 5. Presence -- high-shelf (+-6 dB, dB-mapped)
         // ---------------------------------------------------------
         let pres_alpha = self.alpha(presence_f);
-        self.presence_lp += pres_alpha * (y - self.presence_lp);
+        self.presence_lp = pres_alpha.mul_add(y - self.presence_lp, self.presence_lp);
         let pres_db = (self.presence - 1.0) * 6.0;
         let pres_lin = 10.0_f32.powf(pres_db / 20.0);
         let shelf = (y - self.presence_lp).mul_add(pres_lin, self.presence_lp);

--- a/rustortion-core/src/audio/pitch_shifter.rs
+++ b/rustortion-core/src/audio/pitch_shifter.rs
@@ -7,7 +7,7 @@ use rustfft::num_complex::Complex;
 /// Interpolate between two phases using shortest-path unwrapping.
 fn lerp_phase(ph0: f64, ph1: f64, t: f64) -> f64 {
     let mut d = ph1 - ph0;
-    d -= (d / (2.0 * PI)).round() * 2.0 * PI;
+    d = ((d / (2.0 * PI)).round() * 2.0).mul_add(-PI, d);
     d.mul_add(t, ph0)
 }
 
@@ -189,7 +189,7 @@ impl PitchShifter {
             self.last_phase[k] = phase;
 
             // Wrap to [-π, π]
-            diff -= (diff / (2.0 * PI)).round() * 2.0 * PI;
+            diff = ((diff / (2.0 * PI)).round() * 2.0).mul_add(-PI, diff);
 
             self.analysis_mag[k] = mag;
             self.analysis_freq[k] = (k as f64).mul_add(expected_step, diff);
@@ -228,7 +228,8 @@ impl PitchShifter {
             }
 
             // Wrap to [0, 2π) to prevent precision loss over long sessions
-            self.accum_phase[j] -= (self.accum_phase[j] / (2.0 * PI)).floor() * 2.0 * PI;
+            self.accum_phase[j] = ((self.accum_phase[j] / (2.0 * PI)).floor() * 2.0)
+                .mul_add(-PI, self.accum_phase[j]);
 
             self.shifted_mag[j] = mag;
             self.shifted_phase[j] = self.accum_phase[j];
@@ -292,7 +293,8 @@ impl PitchShifter {
         let scale = self.output_scale;
         for i in 0..FFT_SIZE {
             let pos = (self.output_write + i) % OUTPUT_SIZE;
-            self.output_accum[pos] += self.synth_frame[i] * self.window[i] * scale;
+            self.output_accum[pos] =
+                (self.synth_frame[i] * self.window[i]).mul_add(scale, self.output_accum[pos]);
         }
         self.output_write = (self.output_write + HOP_SIZE) % OUTPUT_SIZE;
     }

--- a/rustortion-core/src/audio/samplers.rs
+++ b/rustortion-core/src/audio/samplers.rs
@@ -11,6 +11,10 @@ pub struct Samplers {
     input_buffer: Vec<Vec<f32>>,
     upsampled_buffer: Vec<Vec<f32>>,
     downsampled_buffer: Vec<Vec<f32>>,
+    /// Number of frames the last `upsample()` call actually produced. The
+    /// chain processes exactly this many frames in place, so `downsample()`
+    /// must feed back exactly this many — not the full buffer capacity.
+    upsampled_frames: usize,
     oversample_factor: f64,
     sample_rate: usize,
 }
@@ -42,6 +46,7 @@ impl Samplers {
         let input_buffer = vec![input_vec];
         let upsampled_buffer = vec![vec![0.0; upsampler.output_frames_max()]; CHANNELS];
         let downsampled_buffer = vec![vec![0.0; downsampler.output_frames_max()]; CHANNELS];
+        let upsampled_frames = upsampled_buffer[0].len();
 
         Ok(Self {
             upsampler,
@@ -49,6 +54,7 @@ impl Samplers {
             input_buffer,
             upsampled_buffer,
             downsampled_buffer,
+            upsampled_frames,
             oversample_factor,
             sample_rate,
         })
@@ -85,12 +91,15 @@ impl Samplers {
             .upsampler
             .process_into_buffer(&input, &mut output, None)
             .context("Upsampler failed")?;
+        self.upsampled_frames = upsampled_frames;
 
         Ok(&mut self.upsampled_buffer[0][..upsampled_frames])
     }
 
     pub fn downsample(&mut self) -> Result<&mut [f32]> {
-        let in_frames = self.upsampled_buffer[0].len();
+        // Feed back exactly the frames the chain just processed in place,
+        // not the full buffer capacity, so no stale tail can leak through.
+        let in_frames = self.upsampled_frames;
         let out_frames = self.downsampled_buffer[0].len();
 
         let input = SequentialSliceOfVecs::new(&self.upsampled_buffer, CHANNELS, in_frames)
@@ -130,6 +139,7 @@ impl Samplers {
         )
         .context("failed to recreate upsampler")?;
         self.upsampled_buffer = vec![vec![0.0; self.upsampler.output_frames_max()]; CHANNELS];
+        self.upsampled_frames = self.upsampled_buffer[0].len();
 
         self.downsampler = Fft::<f32>::new(
             self.sample_rate * self.oversample_factor as usize,

--- a/rustortion-core/src/audio/samplers.rs
+++ b/rustortion-core/src/audio/samplers.rs
@@ -1,12 +1,13 @@
 use anyhow::{Context, Result};
 use log::debug;
-use rubato::{FftFixedInOut, Resampler};
+use rubato::audioadapter_buffers::direct::SequentialSliceOfVecs;
+use rubato::{Fft, FixedSync, Resampler};
 
 const CHANNELS: usize = 1;
 
 pub struct Samplers {
-    upsampler: FftFixedInOut<f32>,
-    downsampler: FftFixedInOut<f32>,
+    upsampler: Fft<f32>,
+    downsampler: Fft<f32>,
     input_buffer: Vec<Vec<f32>>,
     upsampled_buffer: Vec<Vec<f32>>,
     downsampled_buffer: Vec<Vec<f32>>,
@@ -16,27 +17,31 @@ pub struct Samplers {
 
 impl Samplers {
     pub fn new(buffer_size: usize, oversample_factor: f64, sample_rate: usize) -> Result<Self> {
-        let upsampler = FftFixedInOut::new(
+        let upsampler = Fft::<f32>::new(
             sample_rate,
             sample_rate * oversample_factor as usize,
             buffer_size,
+            1,
             CHANNELS,
+            FixedSync::Both,
         )
         .context("failed to create upsampler")?;
 
-        let downsampler = FftFixedInOut::new(
+        let downsampler = Fft::<f32>::new(
             sample_rate * oversample_factor as usize,
             sample_rate,
             buffer_size * oversample_factor as usize,
+            1,
             CHANNELS,
+            FixedSync::Both,
         )
         .context("failed to create downsampler")?;
 
         let mut input_vec = Vec::with_capacity(buffer_size);
         input_vec.resize(buffer_size, 0.0);
         let input_buffer = vec![input_vec];
-        let upsampled_buffer = upsampler.output_buffer_allocate(true);
-        let downsampled_buffer = downsampler.output_buffer_allocate(true);
+        let upsampled_buffer = vec![vec![0.0; upsampler.output_frames_max()]; CHANNELS];
+        let downsampled_buffer = vec![vec![0.0; downsampler.output_frames_max()]; CHANNELS];
 
         Ok(Self {
             upsampler,
@@ -67,18 +72,36 @@ impl Samplers {
     }
 
     pub fn upsample(&mut self) -> Result<&mut [f32]> {
+        let in_frames = self.input_buffer[0].len();
+        let out_frames = self.upsampled_buffer[0].len();
+
+        let input = SequentialSliceOfVecs::new(&self.input_buffer, CHANNELS, in_frames)
+            .map_err(|e| anyhow::anyhow!("upsampler input adapter: {e:?}"))?;
+        let mut output =
+            SequentialSliceOfVecs::new_mut(&mut self.upsampled_buffer, CHANNELS, out_frames)
+                .map_err(|e| anyhow::anyhow!("upsampler output adapter: {e:?}"))?;
+
         let (_, upsampled_frames) = self
             .upsampler
-            .process_into_buffer(&self.input_buffer, &mut self.upsampled_buffer, None)
+            .process_into_buffer(&input, &mut output, None)
             .context("Upsampler failed")?;
 
         Ok(&mut self.upsampled_buffer[0][..upsampled_frames])
     }
 
     pub fn downsample(&mut self) -> Result<&mut [f32]> {
+        let in_frames = self.upsampled_buffer[0].len();
+        let out_frames = self.downsampled_buffer[0].len();
+
+        let input = SequentialSliceOfVecs::new(&self.upsampled_buffer, CHANNELS, in_frames)
+            .map_err(|e| anyhow::anyhow!("downsampler input adapter: {e:?}"))?;
+        let mut output =
+            SequentialSliceOfVecs::new_mut(&mut self.downsampled_buffer, CHANNELS, out_frames)
+                .map_err(|e| anyhow::anyhow!("downsampler output adapter: {e:?}"))?;
+
         let (_, downsampled_frames) = self
             .downsampler
-            .process_into_buffer(&self.upsampled_buffer, &mut self.downsampled_buffer, None)
+            .process_into_buffer(&input, &mut output, None)
             .context("Downsampler failed")?;
 
         Ok(&mut self.downsampled_buffer[0][..downsampled_frames])
@@ -97,23 +120,27 @@ impl Samplers {
 
         self.input_buffer[0].resize(new_size, 0.0);
 
-        self.upsampler = FftFixedInOut::new(
+        self.upsampler = Fft::<f32>::new(
             self.sample_rate,
             self.sample_rate * self.oversample_factor as usize,
             new_size,
+            1,
             CHANNELS,
+            FixedSync::Both,
         )
         .context("failed to recreate upsampler")?;
-        self.upsampled_buffer = self.upsampler.output_buffer_allocate(true);
+        self.upsampled_buffer = vec![vec![0.0; self.upsampler.output_frames_max()]; CHANNELS];
 
-        self.downsampler = FftFixedInOut::new(
+        self.downsampler = Fft::<f32>::new(
             self.sample_rate * self.oversample_factor as usize,
             self.sample_rate,
             new_size * self.oversample_factor as usize,
+            1,
             CHANNELS,
+            FixedSync::Both,
         )
         .context("failed to recreate downsampler")?;
-        self.downsampled_buffer = self.downsampler.output_buffer_allocate(true);
+        self.downsampled_buffer = vec![vec![0.0; self.downsampler.output_frames_max()]; CHANNELS];
 
         Ok(())
     }

--- a/rustortion-core/src/ir/convolver/fft.rs
+++ b/rustortion-core/src/ir/convolver/fft.rs
@@ -181,7 +181,7 @@ impl TwoStageConvolver {
         let mut idx = self.head_write_pos;
 
         for &coeff in &self.head_coeffs {
-            head_out += coeff * self.head_ring[idx];
+            head_out = coeff.mul_add(self.head_ring[idx], head_out);
             if idx == 0 {
                 idx = HEAD_LEN - 1;
             } else {
@@ -291,7 +291,7 @@ impl TwoStageConvolver {
 
         for i in 0..self.block_size {
             let pos = (base + i) % self.block_size;
-            self.ola_buffer[pos] += self.time_scratch[i] * scale;
+            self.ola_buffer[pos] = self.time_scratch[i].mul_add(scale, self.ola_buffer[pos]);
         }
 
         self.ola_write = (self.ola_write + self.partition_size) % self.block_size;

--- a/rustortion-core/src/ir/convolver/fir.rs
+++ b/rustortion-core/src/ir/convolver/fir.rs
@@ -52,7 +52,7 @@ impl FirConvolver {
         let mut idx = self.write_pos;
 
         for &coeff in &self.coefficients {
-            output += self.input_buffer[idx] * coeff;
+            output = self.input_buffer[idx].mul_add(coeff, output);
             if idx == 0 {
                 idx = len - 1;
             } else {

--- a/rustortion-core/src/ir/loader.rs
+++ b/rustortion-core/src/ir/loader.rs
@@ -4,8 +4,10 @@ use log::{debug, warn};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use rubato::audioadapter_buffers::direct::SequentialSliceOfVecs;
 use rubato::{
-    Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
+    Async, FixedAsync, Resampler, SincInterpolationParameters, SincInterpolationType,
+    WindowFunction,
 };
 
 const MAX_IR_LENGTH_SECONDS: u64 = 5;
@@ -184,15 +186,27 @@ fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Result<Vec<f32>> {
         window: WindowFunction::BlackmanHarris2,
     };
 
-    let mut resampler = SincFixedIn::<f32>::new(ratio, 1.0, params, samples.len(), 1)?;
+    let mut resampler =
+        Async::<f32>::new_sinc(ratio, 1.0, &params, samples.len(), 1, FixedAsync::Input)?;
 
     let input = vec![samples.to_vec()];
-    let output = resampler.process(&input, None)?;
+    let input_adapter = SequentialSliceOfVecs::new(&input, 1, samples.len())
+        .map_err(|e| anyhow!("resampler input adapter: {e:?}"))?;
 
-    output
+    let out_frames = resampler.output_frames_next();
+    let mut output = vec![vec![0.0f32; out_frames]; 1];
+    let mut output_adapter = SequentialSliceOfVecs::new_mut(&mut output, 1, out_frames)
+        .map_err(|e| anyhow!("resampler output adapter: {e:?}"))?;
+
+    let (_, frames_written) =
+        resampler.process_into_buffer(&input_adapter, &mut output_adapter, None)?;
+
+    let mut resampled = output
         .into_iter()
         .next()
-        .ok_or_else(|| anyhow!("Resampling failed"))
+        .ok_or_else(|| anyhow!("Resampling failed"))?;
+    resampled.truncate(frames_written);
+    Ok(resampled)
 }
 
 #[cfg(test)]

--- a/rustortion-standalone/Cargo.toml
+++ b/rustortion-standalone/Cargo.toml
@@ -21,7 +21,7 @@ hound = "3.5"
 ctrlc = { version = "3.5", features = ["termination"] }
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "env"] }
-rubato = "0.16"
+rubato = "3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 crossbeam = "0.8"


### PR DESCRIPTION
## Summary

Upgrades `rubato` from `0.16` to `3.0` and refreshes the rest of the dependency lockfile. This supersedes dependabot #241, which only bumped the manifest version — rubato 3.0 is a full API rewrite, so the bump alone would not compile.

## rubato 0.16 → 3.0 migration

The v1.0.0 rewrite merged the resampler types and moved buffers behind the `audioadapter` crate. Mappings, chosen to preserve behaviour:

| Usage | Before | After |
|-------|--------|-------|
| RT oversampling (`samplers.rs`) | `FftFixedInOut` | `Fft` + `FixedSync::Both` |
| Offline IR resample (`loader.rs`) | `SincFixedIn` + `process()` | `Async::new_sinc(…, FixedAsync::Input)` + `process_into_buffer` |
| Benchmark | `SincFixedIn`/`FastFixedIn`/`FftFixedIn`/`FftFixedOut` | merged `Async`/`Fft` |

### Behaviour preservation

- **RT path:** v3's `FixedSync::Both` uses the *identical* FFT-sizing formula as v0.16's `FftFixedInOut` (same `fft_chunks = ceil(chunk/(rate_in/gcd))`, same single `FftResampler`, same BlackmanHarris2 sinc filter). `sub_chunks` is ignored in `Both` mode, so the DSP output is unchanged for the integer oversampling ratios used here.
- **IR loader:** same `SincInterpolationParameters`; uses a single `process_into_buffer` call (not `process_all_into_buffer`, which would trim the resampler delay and change the output).
- **Buffers:** `SequentialSliceOfVecs` wraps the existing `Vec<Vec<f32>>` and allocates nothing on the audio thread.

## Other dependencies

`cargo update` within existing semver constraints: `serde_json` 1.0.149 → 1.0.150 (the other half of dependabot #241) plus compatible transitive bumps.

## Verification

- `make lint` (fmt + clippy `-D warnings -D pedantic -D nursery`) — clean across all crates
- `make test` — 148 lib + integration tests pass
- **RT no-alloc suite passes**, including `engine_process_does_not_allocate_with_oversampling`, confirming the new adapters allocate nothing on the audio thread
- Benchmarks compile and run