### PR TITLE
test(nam): guard model-name recall + document deferred automation

### DIFF
--- a/rustortion-core/src/preset/stage_config.rs
+++ b/rustortion-core/src/preset/stage_config.rs
@@ -197,3 +197,47 @@ impl StageConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The plugin persists its chain as `Vec<StageConfig>` JSON in `chain_state`
+    /// (nih-plug `#[persist]`), and a NAM stage stores its model BY NAME. This is
+    /// the exact path that recalls a selected model when a DAW project reopens, so
+    /// guard it: the model name (and the other NAM fields) must survive a JSON
+    /// round-trip. See NAM-6.
+    #[test]
+    fn nam_model_name_survives_chain_state_round_trip() {
+        let chain = vec![
+            StageConfig::Nam(NamConfig {
+                model_name: Some("S-[AMP] Divine Sheep #04".to_owned()),
+                input_gain_db: 3.0,
+                output_gain_db: -2.0,
+                mix: 0.75,
+                bypassed: true,
+            }),
+            // A passthrough NAM stage (no model) must round-trip as `None`, not "".
+            StageConfig::Nam(NamConfig::default()),
+        ];
+
+        let json = serde_json::to_string(&chain).expect("serialize chain_state");
+        let restored: Vec<StageConfig> =
+            serde_json::from_str(&json).expect("deserialize chain_state");
+
+        assert_eq!(restored.len(), 2);
+        let StageConfig::Nam(cfg) = &restored[0] else {
+            panic!("expected a NAM stage at index 0");
+        };
+        assert_eq!(cfg.model_name.as_deref(), Some("S-[AMP] Divine Sheep #04"));
+        assert!((cfg.input_gain_db - 3.0).abs() < f32::EPSILON);
+        assert!((cfg.output_gain_db - (-2.0)).abs() < f32::EPSILON);
+        assert!((cfg.mix - 0.75).abs() < f32::EPSILON);
+        assert!(cfg.bypassed);
+
+        let StageConfig::Nam(cfg) = &restored[1] else {
+            panic!("expected a NAM stage at index 1");
+        };
+        assert_eq!(cfg.model_name, None);
+    }
+}

--- a/rustortion-core/src/preset/stage_config.rs
+++ b/rustortion-core/src/preset/stage_config.rs
@@ -230,9 +230,12 @@ mod tests {
             panic!("expected a NAM stage at index 0");
         };
         assert_eq!(cfg.model_name.as_deref(), Some("S-[AMP] Divine Sheep #04"));
-        assert!((cfg.input_gain_db - 3.0).abs() < f32::EPSILON);
-        assert!((cfg.output_gain_db - (-2.0)).abs() < f32::EPSILON);
-        assert!((cfg.mix - 0.75).abs() < f32::EPSILON);
+        // Small fixed tolerance — `f32::EPSILON` is the spacing near 1.0, not a
+        // general-purpose comparison bound.
+        const TOL: f32 = 1e-6;
+        assert!((cfg.input_gain_db - 3.0).abs() < TOL);
+        assert!((cfg.output_gain_db - (-2.0)).abs() < TOL);
+        assert!((cfg.mix - 0.75).abs() < TOL);
         assert!(cfg.bypassed);
 
         let StageConfig::Nam(cfg) = &restored[1] else {

--- a/rustortion-core/src/preset/stage_config.rs
+++ b/rustortion-core/src/preset/stage_config.rs
@@ -206,7 +206,7 @@ mod tests {
     /// (nih-plug `#[persist]`), and a NAM stage stores its model BY NAME. This is
     /// the exact path that recalls a selected model when a DAW project reopens, so
     /// guard it: the model name (and the other NAM fields) must survive a JSON
-    /// round-trip. See NAM-6.
+    /// round-trip.
     #[test]
     fn nam_model_name_survives_chain_state_round_trip() {
         let chain = vec![

--- a/rustortion-plugin/src/params.rs
+++ b/rustortion-plugin/src/params.rs
@@ -487,9 +487,9 @@ impl Default for EqSlotParams {
 /// serialized `chain_state`, so it persists with and recalls from the DAW project
 /// (the chain is rebuilt and each NAM stage resolves its model by name on load).
 /// Name-based recall is robust against the model list reordering. Exposing model
-/// choice as a host-automatable param is deferred to REF-Q3 — it needs the general
-/// slot<->stage param pump (and a background reload, since switching models loads a
-/// neural net off the audio thread), with no clean NAM-only slice.
+/// choice as a host-automatable param is deferred — it needs a general slot<->stage
+/// param pump (and a background reload, since switching models loads a neural net
+/// off the audio thread), with no clean NAM-only slice.
 #[derive(Params)]
 pub struct NamSlotParams {
     #[id = "input_gain_db"]

--- a/rustortion-plugin/src/params.rs
+++ b/rustortion-plugin/src/params.rs
@@ -481,6 +481,15 @@ impl Default for EqSlotParams {
     }
 }
 
+/// Per-slot NAM params — intentionally **no** `model` parameter here.
+///
+/// The selected model is stored by NAME in `NamConfig.model_name` inside the
+/// serialized `chain_state`, so it persists with and recalls from the DAW project
+/// (the chain is rebuilt and each NAM stage resolves its model by name on load).
+/// Name-based recall is robust against the model list reordering. Exposing model
+/// choice as a host-automatable param is deferred to REF-Q3 — it needs the general
+/// slot<->stage param pump (and a background reload, since switching models loads a
+/// neural net off the audio thread), with no clean NAM-only slice.
 #[derive(Params)]
 pub struct NamSlotParams {
     #[id = "input_gain_db"]


### PR DESCRIPTION
## What

Closes the realistic half of NAM-6. Investigation showed the plugin's `process()` reads only a few global params and applies them; per-slot stage params (incl. NAM model) reach the engine only via the GUI editor path, so host automation of per-stage knobs isn't wired for any stage. That general gap is tracked separately (REF-Q3).

What *does* work today is **recall**: a NAM stage stores its model by name in `NamConfig.model_name`, which lives in the `chain_state` JSON nih-plug persists with the DAW project. On load the chain is rebuilt and each NAM stage resolves its model by name. This PR locks that in and documents the boundary.

## Changes

- **Test** (`rustortion-core/src/preset/stage_config.rs`): serde round-trip of `Vec<StageConfig>` — the exact representation `chain_state` persists — asserting `model_name` (and the other NAM fields) survive, including `None` for a passthrough NAM stage.
- **Doc note** (`rustortion-plugin/src/params.rs`): on `NamSlotParams`, explaining there is intentionally no `model` host param — name-based recall works, and host automation is deferred to the general slot↔stage param pump (it needs a background reload since switching models loads a neural net off the audio thread, with no clean NAM-only slice).

## Verification

`make lint` clean · `make test` green (new test passes).

NAM-6: recall done; automation folded into the cross-cutting REF-Q3 (tracked internally).