### PR TITLE
fix(ui): suffix slider step literals to satisfy float_literal_f32_fallback

### DIFF
--- a/rustortion-ui/src/app.rs
+++ b/rustortion-ui/src/app.rs
@@ -546,7 +546,7 @@ impl<B: ParamBackend> SharedApp<B> {
                     Message::InputFilterHighpassCutoff
                 )
                 .width(Length::FillPortion(5))
-                .step(1.0),
+                .step(1.0_f32),
                 text(format!(
                     "{:.0} {}",
                     self.input_filter_config.hp_cutoff,
@@ -571,7 +571,7 @@ impl<B: ParamBackend> SharedApp<B> {
                     Message::InputFilterLowpassCutoff
                 )
                 .width(Length::FillPortion(5))
-                .step(1.0),
+                .step(1.0_f32),
                 text(format!(
                     "{:.0} {}",
                     self.input_filter_config.lp_cutoff,

--- a/rustortion-ui/src/components/ir_cabinet_control.rs
+++ b/rustortion-ui/src/components/ir_cabinet_control.rs
@@ -85,7 +85,7 @@ impl IrCabinetControl {
             text(gain_label).width(Length::Fixed(80.0)),
             slider(0.0..=1.0, self.gain, Message::IrGainChanged)
                 .width(Length::FillPortion(7))
-                .step(0.01),
+                .step(0.01_f32),
             text(format!("{:.0}%", self.gain * 100.0)).width(Length::FillPortion(2)),
         ]
         .spacing(SPACING_NORMAL)


### PR DESCRIPTION
## Problem

CI's Lint job is failing on `main` and on every open PR (e.g. #264, a dependabot bump that has nothing to do with these files):

```
error: falling back to `f32` as the trait bound `f32: From<f64>` is not satisfied
   --> rustortion-ui/src/app.rs:549:23
    |
549 |                 .step(1.0),
    |                       ^^^ help: explicitly specify the type as `f32`: `1.0_f32`
    |
    = note: `-D float-literal-f32-fallback` implied by `-D warnings`
error: could not compile `rustortion-ui` (lib) due to 3 previous errors
```

This is **toolchain drift**, not a code regression. CI uses `dtolnay/rust-toolchain@stable`, which now resolves to **1.97.0**. That release adds the future-incompatible lint [`float_literal_f32_fallback`](https://github.com/rust-lang/rust/issues/154024), which fires on unsuffixed float literals whose type is only settled by inference fallback. Our `-D warnings` turns it into a hard error.

## Fix

Suffix the three affected slider `.step()` literals as `_f32` — exactly what rustc suggests.

- `rustortion-ui/src/app.rs` — HP and LP cutoff sliders
- `rustortion-ui/src/components/ir_cabinet_control.rs` — IR gain slider

**No behaviour change.** These literals already resolved to `f32`; the suffix just states it explicitly instead of leaning on fallback.

## Verification

The lint doesn't exist on older toolchains, so a local `make lint` on 1.95 passes even *without* this fix — it can't prove anything. Verified against 1.97 specifically, matching CI:

```
$ rustc +1.97 -W help | grep float-literal
  float-literal-f32-fallback  warn  detects unsuffixed floating point literals whose type fallback to `f32`

$ cargo +1.97 clippy --workspace --all-targets --all-features -- \
    -D warnings -D clippy::all -D clippy::pedantic -D clippy::nursery
    Finished `dev` profile [optimized + debuginfo] target(s) in 16.86s

$ cargo +1.97 fmt --all -- --check
(clean)
```

## Note on #264

#264 needs this on `main` and then a rebase — its own diff is unrelated. Once this lands, dependabot will rebase and its Lint job should go green.