### PR TITLE
perf(rt): enable FTZ/DAZ on the audio thread and clean up denormal handling

### DIFF
--- a/rustortion-core/benches/chain.rs
+++ b/rustortion-core/benches/chain.rs
@@ -13,6 +13,7 @@ use rustortion_core::amp::stages::{
     preamp::PreampStage,
     tonestack::{ToneStackModel, ToneStackStage},
 };
+use rustortion_core::audio::denormals::enable_flush_to_zero;
 use rustortion_core::nam::{NamLoader, registry};
 use std::hint::black_box;
 use std::path::Path;
@@ -74,6 +75,10 @@ fn build_chain(sample_rate: f32) -> AmplifierChain {
 }
 
 fn bench_sample_vs_block(c: &mut Criterion) {
+    // Match the RT audio callback: denormals flushed to zero, so the numbers
+    // reflect production rather than denormal-stalled arithmetic.
+    enable_flush_to_zero();
+
     let mut group = c.benchmark_group("Sample vs Block Processing");
 
     for &oversample in &[1.0, 4.0, 8.0, 16.0] {
@@ -126,6 +131,10 @@ fn load_first_nam_model() -> Option<String> {
 }
 
 fn bench_nam_sample_vs_block(c: &mut Criterion) {
+    // Match the RT audio callback: denormals flushed to zero, so the numbers
+    // reflect production rather than denormal-stalled arithmetic.
+    enable_flush_to_zero();
+
     let Some(model_name) = load_first_nam_model() else {
         eprintln!("skipping NAM bench: no .nam model found in tests/fixtures");
         return;
@@ -177,6 +186,10 @@ fn bench_nam_sample_vs_block(c: &mut Criterion) {
 /// loop on the same model, no chain, no gain/mix. This is the maximum speedup a
 /// `NamStage::process_block` override could capture by calling `process_buffer`.
 fn bench_nam_buffer_vs_sample(c: &mut Criterion) {
+    // Match the RT audio callback: denormals flushed to zero, so the numbers
+    // reflect production rather than denormal-stalled arithmetic.
+    enable_flush_to_zero();
+
     let Some(model_name) = load_first_nam_model() else {
         eprintln!("skipping NAM ceiling bench: no .nam model found");
         return;

--- a/rustortion-core/benches/engine.rs
+++ b/rustortion-core/benches/engine.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::pedantic, clippy::nursery)]
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rustortion_core::audio::denormals::enable_flush_to_zero;
 use std::hint::black_box;
 
 use rustortion_core::amp::chain::AmplifierChain;
@@ -42,6 +43,10 @@ pub fn build_engine(
 }
 
 fn bench_engine_buffer_sizes(c: &mut Criterion) {
+    // Match the RT audio callback: denormals flushed to zero, so the numbers
+    // reflect production rather than denormal-stalled arithmetic.
+    enable_flush_to_zero();
+
     let mut group = c.benchmark_group("Engine Buffer Sizes");
 
     for &buffer_size in &[64, 128, 256, 512] {
@@ -73,6 +78,10 @@ fn bench_engine_buffer_sizes(c: &mut Criterion) {
 }
 
 fn bench_engine_throughput(c: &mut Criterion) {
+    // Match the RT audio callback: denormals flushed to zero, so the numbers
+    // reflect production rather than denormal-stalled arithmetic.
+    enable_flush_to_zero();
+
     use criterion::Throughput;
 
     let mut group = c.benchmark_group("Engine Throughput");
@@ -101,6 +110,10 @@ fn bench_engine_throughput(c: &mut Criterion) {
 }
 
 fn bench_engine_with_ir_cabinet(c: &mut Criterion) {
+    // Match the RT audio callback: denormals flushed to zero, so the numbers
+    // reflect production rather than denormal-stalled arithmetic.
+    enable_flush_to_zero();
+
     let mut group = c.benchmark_group("Engine With IR Cabinet");
 
     for &oversample in &[1.0, 4.0, 8.0] {
@@ -139,6 +152,10 @@ fn bench_engine_with_ir_cabinet(c: &mut Criterion) {
 }
 
 fn bench_engine_ir_lengths(c: &mut Criterion) {
+    // Match the RT audio callback: denormals flushed to zero, so the numbers
+    // reflect production rather than denormal-stalled arithmetic.
+    enable_flush_to_zero();
+
     let mut group = c.benchmark_group("Engine IR Lengths");
 
     for &ir_length in &[1_000, 13_000, 34_000, 87_000] {

--- a/rustortion-core/benches/impulse_responses.rs
+++ b/rustortion-core/benches/impulse_responses.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::pedantic, clippy::nursery)]
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rustortion_core::audio::denormals::enable_flush_to_zero;
 use std::hint::black_box;
 
 use rustortion_core::ir::convolver::{FirConvolver, TwoStageConvolver};
@@ -31,6 +32,10 @@ fn generate_test_input(size: usize) -> Vec<f32> {
 }
 
 pub fn fir_vs_two_stage_benchmark(c: &mut Criterion) {
+    // Match the RT audio callback: denormals flushed to zero, so the numbers
+    // reflect production rather than denormal-stalled arithmetic.
+    enable_flush_to_zero();
+
     let mut group = c.benchmark_group("FIR vs TwoStage");
 
     // Test at different IR lengths relevant to cabinet simulation

--- a/rustortion-core/benches/samplers.rs
+++ b/rustortion-core/benches/samplers.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::pedantic, clippy::nursery)]
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rustortion_core::audio::denormals::enable_flush_to_zero;
 use std::hint::black_box;
 
 use rubato::audioadapter_buffers::direct::SequentialSliceOfVecs;
@@ -235,6 +236,10 @@ fn run_roundtrip(
 }
 
 fn bench_resampler_roundtrip(c: &mut Criterion) {
+    // Match the RT audio callback: denormals flushed to zero, so the numbers
+    // reflect production rather than denormal-stalled arithmetic.
+    enable_flush_to_zero();
+
     let mut group = c.benchmark_group("Resampler Roundtrip");
     group.throughput(Throughput::Elements(BUFFER_SIZE as u64));
 

--- a/rustortion-core/src/amp/stages/common.rs
+++ b/rustortion-core/src/amp/stages/common.rs
@@ -107,7 +107,7 @@ impl EnvelopeFollower {
         self.envelope
     }
 
-    /// Reset envelope to zero (denormal flush).
+    /// Reset the envelope to zero, discarding any accumulated state.
     pub const fn reset(&mut self) {
         self.envelope = 0.0;
     }

--- a/rustortion-core/src/amp/stages/delay.rs
+++ b/rustortion-core/src/amp/stages/delay.rs
@@ -6,7 +6,6 @@ use crate::amp::stages::common::calculate_coefficient;
 const MAX_DELAY_MS: f32 = 2000.0;
 const MAX_FEEDBACK: f32 = 0.95;
 const SMOOTH_TIME_MS: f32 = 50.0;
-const DENORMAL_THRESHOLD: f32 = 1e-20;
 
 /// Delay stage for echo and slapback effects.
 ///
@@ -76,13 +75,8 @@ impl Stage for DelayStage {
         // Linear interpolation between the two nearest samples
         let delayed = (1.0 - frac).mul_add(self.buffer[read_idx], frac * self.buffer[prev_idx]);
 
-        // Write input + feedback into buffer, flush denormals
-        let write_val = self.feedback.mul_add(delayed, input);
-        self.buffer[self.write_pos] = if write_val.abs() < DENORMAL_THRESHOLD {
-            0.0
-        } else {
-            write_val
-        };
+        // Write input + feedback into buffer
+        self.buffer[self.write_pos] = self.feedback.mul_add(delayed, input);
 
         // Advance write position
         self.write_pos = (self.write_pos + 1) % buf_len;

--- a/rustortion-core/src/amp/stages/eq.rs
+++ b/rustortion-core/src/amp/stages/eq.rs
@@ -11,7 +11,6 @@ pub const BAND_FREQS: [f64; NUM_BANDS] = [
 ];
 pub const MIN_GAIN_DB: f32 = -12.0;
 pub const MAX_GAIN_DB: f32 = 12.0;
-const DENORMAL_THRESHOLD: f64 = 1e-20;
 
 /// Bandwidth in octaves: 10 octaves / 16 bands
 const BANDWIDTH: f64 = 10.0 / NUM_BANDS as f64;
@@ -125,9 +124,6 @@ impl Biquad {
             .b0
             .mul_add(input, self.b1.mul_add(self.x1, self.b2 * self.x2))
             - self.a1.mul_add(self.y1, self.a2 * self.y2);
-
-        // Flush denormals
-        let y = if y.abs() < DENORMAL_THRESHOLD { 0.0 } else { y };
 
         self.x2 = self.x1;
         self.x1 = input;
@@ -311,23 +307,6 @@ mod tests {
         // Unknown parameter name
         assert!(eq.set_parameter("volume", 0.0).is_err());
         assert!(eq.get_parameter("volume").is_err());
-    }
-
-    #[test]
-    fn denormal_flushing() {
-        let mut eq = EqStage::new(flat_gains(), SAMPLE_RATE);
-
-        // Feed very small signal, then silence — state should not accumulate denormals
-        for _ in 0..100 {
-            eq.process(1e-30);
-        }
-        for _ in 0..1000 {
-            let out = eq.process(0.0);
-            assert!(
-                out == 0.0 || out.abs() >= f32::MIN_POSITIVE,
-                "Should not produce denormal values, got {out}"
-            );
-        }
     }
 
     #[test]

--- a/rustortion-core/src/amp/stages/poweramp.rs
+++ b/rustortion-core/src/amp/stages/poweramp.rs
@@ -61,10 +61,6 @@ impl Stage for PowerAmpStage {
 
         self.sag_envelope.process(driven);
 
-        if self.sag_envelope.value().abs() < 1e-20 {
-            self.sag_envelope.reset();
-        }
-
         let ceiling = (self.sag * self.sag_envelope.value())
             .mul_add(-0.5, 1.0)
             .max(0.1);
@@ -268,22 +264,6 @@ mod tests {
         // Out of range should fail
         assert!(stage.set_parameter("sag_release", 201.0).is_err());
         assert!(stage.set_parameter("sag_release", 39.0).is_err());
-    }
-
-    #[test]
-    fn test_denormal_protection() {
-        let mut stage = make_stage(PowerAmpType::ClassAB, 0.5, 0.5, 120.0);
-        for _ in 0..1000 {
-            stage.process(1.0);
-        }
-        for _ in 0..100_000 {
-            stage.process(0.0);
-        }
-        let envelope = stage.sag_envelope.value();
-        assert!(
-            envelope == 0.0 || envelope.abs() > 1e-20,
-            "envelope should be zero or normal, got {envelope}"
-        );
     }
 
     #[test]

--- a/rustortion-core/src/amp/stages/reverb.rs
+++ b/rustortion-core/src/amp/stages/reverb.rs
@@ -13,8 +13,6 @@ const SCALE_DAMP: f32 = 0.4;
 const INPUT_GAIN: f32 = 0.015;
 const ALLPASS_FEEDBACK: f32 = 0.5;
 
-const DENORMAL_THRESHOLD: f32 = 1e-20;
-
 /// Lowpass-feedback comb filter used in Freeverb.
 struct CombFilter {
     buffer: Vec<f32>,
@@ -42,16 +40,8 @@ impl CombFilter {
 
         // One-pole lowpass in feedback path
         self.filterstore = self.damp2.mul_add(output, self.damp1 * self.filterstore);
-        if self.filterstore.abs() < DENORMAL_THRESHOLD {
-            self.filterstore = 0.0;
-        }
 
-        let write_val = self.feedback.mul_add(self.filterstore, input);
-        self.buffer[self.write_pos] = if write_val.abs() < DENORMAL_THRESHOLD {
-            0.0
-        } else {
-            write_val
-        };
+        self.buffer[self.write_pos] = self.feedback.mul_add(self.filterstore, input);
 
         self.write_pos += 1;
         if self.write_pos >= self.buffer.len() {
@@ -89,12 +79,7 @@ impl AllpassFilter {
         let bufout = self.buffer[self.write_pos];
         let output = bufout - input;
 
-        let write_val = ALLPASS_FEEDBACK.mul_add(bufout, input);
-        self.buffer[self.write_pos] = if write_val.abs() < DENORMAL_THRESHOLD {
-            0.0
-        } else {
-            write_val
-        };
+        self.buffer[self.write_pos] = ALLPASS_FEEDBACK.mul_add(bufout, input);
 
         self.write_pos += 1;
         if self.write_pos >= self.buffer.len() {
@@ -169,11 +154,6 @@ impl Stage for ReverbStage {
         // Pass through 4 series allpass filters
         for allpass in &mut self.allpasses {
             out = allpass.process(out);
-        }
-
-        // Flush denormals
-        if out.abs() < DENORMAL_THRESHOLD {
-            out = 0.0;
         }
 
         // Dry/wet mix

--- a/rustortion-core/src/audio/denormals.rs
+++ b/rustortion-core/src/audio/denormals.rs
@@ -1,0 +1,177 @@
+//! CPU denormal handling for the real-time audio path.
+//!
+//! Denormal (subnormal) floats are handled by microcode on most x86 CPUs and cost on the order of
+//! 100x a normal multiply. They show up naturally in this chain: IIR filter state in
+//! [`crate::amp::stages::filter`] and any feedback/decay path keep multiplying their own output by
+//! a coefficient below 1.0, so as soon as the guitar signal stops the state slides down through the
+//! denormal range instead of reaching zero. The result is a CPU spike precisely when the DSP is
+//! doing nothing useful.
+//!
+//! Rather than sprinkling per-stage denormal guards (adding a tiny DC offset, or clamping state)
+//! through every filter and delay, we flip the CPU's own denormal-control bits once at the entry
+//! point of the audio callback. That covers the whole chain, including third-party DSP, for a
+//! handful of cycles.
+//!
+//! # Per-thread state
+//!
+//! **MXCSR (x86) and FPCR (`AArch64`) are per-thread register state.** Setting them on one thread
+//! says nothing about any other thread. That is why [`enable_flush_to_zero`] is called at the top
+//! of *every* process callback rather than once when the audio thread starts:
+//!
+//! * JACK, and plugin hosts generally, are free to hand us a different thread — after a graph
+//!   reorder, a freewheel/export pass, or a thread-pool change — with no notification.
+//! * Some hosts and drivers reset or restore MXCSR around their own code.
+//! * The cost is a register read plus a conditional register write, which is negligible next to a
+//!   whole block of amp simulation.
+//!
+//! Unlike nih-plug's `ScopedFtz`, we do not restore the previous value on exit. The standalone JACK
+//! process thread is ours for its entire lifetime and runs nothing but this chain, so there is
+//! nobody to restore it for.
+//!
+//! # Real-time safety
+//!
+//! No allocation, no locks, no I/O, no logging — safe to call from the audio callback.
+
+/// Flush-to-zero: MXCSR bit 15. Denormal *results* are flushed to zero.
+///
+/// See Intel SDM Vol. 1 section 10.2.3.3 (Flush-To-Zero).
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "sse"
+))]
+const MXCSR_FLUSH_TO_ZERO: u32 = 1 << 15;
+
+/// Denormals-are-zero: MXCSR bit 6. Denormal *inputs* are treated as zero.
+///
+/// This bit is an SSE2 addition (Intel SDM Vol. 1 section 10.2.3.4). It is unconditionally
+/// available on `x86_64`, but on 32-bit x86 a pre-SSE2 CPU treats bit 6 as reserved and writing it
+/// raises `#GP`, so it is gated on the `sse2` target feature.
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "sse2"
+))]
+const MXCSR_DENORMALS_ARE_ZERO: u32 = 1 << 6;
+
+/// `AArch64` flush-to-zero: FPCR bit 24 (`FZ`).
+///
+/// See the Arm Architecture Reference Manual, FPCR (Floating-point Control Register).
+#[cfg(target_arch = "aarch64")]
+const FPCR_FLUSH_TO_ZERO: u64 = 1 << 24;
+
+/// Enables flush-to-zero (and, where available, denormals-are-zero) for the **calling thread**.
+///
+/// Call this at the top of every real-time audio callback. See the [module docs](self) for why it
+/// is per-callback rather than once per thread, and for the real-time safety guarantees.
+///
+/// On architectures without a denormal-control register we know about, this is a no-op.
+#[inline]
+pub fn enable_flush_to_zero() {
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature = "sse"
+    ))]
+    {
+        // `_mm_getcsr`/`_mm_setcsr` and the `_MM_SET_FLUSH_ZERO_MODE`/`_MM_SET_DENORMALS_ZERO_MODE`
+        // wrappers were deprecated in Rust 1.75, so the register has to be touched via inline asm.
+        let mut wanted = MXCSR_FLUSH_TO_ZERO;
+        #[cfg(target_feature = "sse2")]
+        {
+            wanted |= MXCSR_DENORMALS_ARE_ZERO;
+        }
+
+        let mut mxcsr: u32 = 0;
+        // SAFETY: `stmxcsr` stores the 32-bit MXCSR register through the given pointer, which
+        // points at an initialised, correctly aligned, exclusively borrowed `u32` on our stack.
+        unsafe {
+            core::arch::asm!("stmxcsr [{}]", in(reg) &raw mut mxcsr, options(nostack, preserves_flags));
+        }
+
+        let updated = mxcsr | wanted;
+        if updated != mxcsr {
+            // SAFETY: `ldmxcsr` loads MXCSR from the given pointer, which points at an initialised,
+            // correctly aligned `u32` on our stack. `updated` only ever sets bits 15 and (when
+            // SSE2 is available) 6, both of which are defined and writable, so no reserved bit is
+            // set and this cannot raise `#GP`.
+            unsafe {
+                core::arch::asm!("ldmxcsr [{}]", in(reg) &raw const updated, options(nostack, preserves_flags));
+            }
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        // There are no stable intrinsics for FPCR, so this needs inline asm too.
+        let fpcr: u64;
+        // SAFETY: `mrs`/`msr` on FPCR are unprivileged and always available on AArch64. Reading
+        // and writing the calling thread's own floating-point control register has no effect on
+        // memory or on any other thread.
+        unsafe {
+            core::arch::asm!("mrs {}, fpcr", out(reg) fpcr, options(nomem, nostack, preserves_flags));
+        }
+
+        let updated = fpcr | FPCR_FLUSH_TO_ZERO;
+        if updated != fpcr {
+            // SAFETY: see above; only the defined `FZ` bit is being set.
+            unsafe {
+                core::arch::asm!("msr fpcr, {}", in(reg) updated, options(nomem, nostack, preserves_flags));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::enable_flush_to_zero;
+    use std::hint::black_box;
+
+    /// Smallest positive denormal `f32`. Halving `f32::MIN_POSITIVE` lands in denormal range.
+    const DENORMAL: f32 = f32::MIN_POSITIVE / 2.0;
+
+    #[test]
+    fn is_callable_and_idempotent() {
+        enable_flush_to_zero();
+        enable_flush_to_zero();
+    }
+
+    /// Sanity check that the constant we build the test around really is subnormal, and that
+    /// without FTZ the multiply below would produce a (nonzero) denormal.
+    #[test]
+    fn denormal_constant_is_subnormal() {
+        assert!(black_box(DENORMAL).is_subnormal());
+    }
+
+    /// Multiplying a denormal by a normal value yields a denormal result, which FTZ must flush to
+    /// exactly zero.
+    ///
+    /// `black_box` on both operands is load-bearing: without it the optimiser is free to constant
+    /// fold this at compile time, where FTZ does not apply, and the test would pass or fail for
+    /// reasons unrelated to the runtime MXCSR/FPCR state.
+    #[cfg(any(
+        all(
+            any(target_arch = "x86", target_arch = "x86_64"),
+            target_feature = "sse"
+        ),
+        target_arch = "aarch64"
+    ))]
+    #[test]
+    fn denormal_result_flushes_to_zero() {
+        enable_flush_to_zero();
+
+        let product = black_box(DENORMAL) * black_box(0.5_f32);
+        assert_eq!(black_box(product), 0.0_f32);
+    }
+
+    /// On x86 with SSE2, DAZ additionally makes a denormal *input* read as zero, so adding a
+    /// denormal to zero also gives exactly zero rather than the denormal itself.
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature = "sse2"
+    ))]
+    #[test]
+    fn denormal_input_reads_as_zero() {
+        enable_flush_to_zero();
+
+        let sum = black_box(DENORMAL) + black_box(0.0_f32);
+        assert_eq!(black_box(sum), 0.0_f32);
+    }
+}

--- a/rustortion-core/src/audio/mod.rs
+++ b/rustortion-core/src/audio/mod.rs
@@ -1,3 +1,4 @@
+pub mod denormals;
 pub mod engine;
 pub mod peak_meter;
 pub mod pitch_shifter;

--- a/rustortion-standalone/src/audio/jack.rs
+++ b/rustortion-standalone/src/audio/jack.rs
@@ -6,6 +6,7 @@ use jack::Client;
 use log::{error, warn};
 
 use crate::audio::ports::Ports;
+use rustortion_core::audio::denormals::enable_flush_to_zero;
 use rustortion_core::audio::engine::Engine;
 
 pub struct NotificationHandler {
@@ -67,6 +68,11 @@ impl ProcessHandler {
 
 impl jack::ProcessHandler for ProcessHandler {
     fn process(&mut self, _client: &jack::Client, ps: &jack::ProcessScope) -> jack::Control {
+        // MXCSR/FPCR are per-thread state and JACK may hand us a different thread after a graph
+        // change, so this is re-applied every callback rather than once at thread start. It costs a
+        // register read and (usually not even) a write. See `denormals` for the full rationale.
+        enable_flush_to_zero();
+
         let input = self.ports.get_input(ps);
 
         if let Err(e) = self.audio_engine.process(input, self.buffer.as_mut_slice()) {


### PR DESCRIPTION
Closes #251.

Denormal floats cost roughly 100x a normal multiply on x86, and nothing in the repo had ever set
the CPU's denormal-control bits — a grep for `FTZ`, `DAZ` or `_MM_SETCSR` returned zero hits.
`FilterStage` carries IIR state with no flush at all, and every reverb/delay feedback path decays
into denormals whenever the input goes quiet.

## What this does

Adds `core::audio::denormals::enable_flush_to_zero()`, called at the top of the standalone JACK
process callback:

- **x86/x86_64**: MXCSR FTZ (bit 15), plus DAZ (bit 6) where SSE2 is available
- **aarch64**: FPCR FZ (bit 24) via `mrs`/`msr`
- **everything else**: compiles to a no-op

Inline `asm!` rather than intrinsics because `_MM_SET_FLUSH_ZERO_MODE` and friends were deprecated
in Rust 1.75 and are unusable under `-D warnings`. Called per callback rather than once per thread,
since a host may hand us a different thread after a graph reorder with no notification.

The plugin already gets equivalent coverage from nih-plug's `ScopedFtz` — verified in the pinned
rev. Worth knowing: **nih-plug sets FTZ but not DAZ**, so the plugin flushes denormal results but
still pays full cost on denormal *inputs* (a denormal buffer from the host, or denormal IR/NAM
coefficients). Our own helper sets both.

## Denormal handling cleanup

The per-stage guards in `reverb.rs` (x4), `delay.rs`, `eq.rs` and `poweramp.rs` were thresholded at
`1e-20` — about 18 orders of magnitude above where f32 denormals begin (~1.18e-38) and 288 above
f64's (~2.2e-308). They were noise gates at exactly -400 dBFS, not denormal flushes, and the branch
per sample they cost is now handled for free in hardware.

Removing them lets tails decay continuously below -400 dBFS instead of snapping to zero. Inaudible
— ~340 dB below anything you can hear, ~250 dB below a 24-bit LSB — but a real change rather than a
no-op, so it's stated rather than glossed.

## Deleted tests

`eq::denormal_flushing` and `poweramp::test_denormal_protection` are deleted rather than retrofitted.
Denormal behaviour is now a property of the RT entry point and is tested there, next to the register
write, by `denormal_result_flushes_to_zero` and `denormal_input_reads_as_zero` (both `black_box`-guarded
against constant folding, and both verified to fail without the FTZ call).

Both deleted tests were vacuous anyway:

- `eq::denormal_flushing` built the EQ with `flat_gains()`, which takes the unity-passthrough branch
  (`b0=1`, rest 0), so the biquad state never decayed — the assertion passed via its `out == 0.0` arm
  on every iteration.
- `poweramp::test_denormal_protection` ran 100k samples of silence against a 120 ms release, reaching
  only ~6e-9 — nine decades above the guard it was named for. Reaching true f32 denormal range would
  have needed ~463k samples.

Neither guard ever fired in its own test.

## Also

Benches now enable FTZ, so they stop measuring denormal-stalled arithmetic that production never
sees. This may shift bench baselines in the faster direction independently of the guard removal.

`EnvelopeFollower::reset()` keeps its code but loses a misleading "denormal flush" doc comment; it
now has zero callers and could be dropped in a follow-up.

`make lint` clean, 230 tests passing, verified standalone against `main`.