### PR TITLE
chore(ci): pin the Rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+[toolchain]
+# Pinned deliberately. CI uses dtolnay/rust-toolchain@stable, and new clippy
+# lints have failed CI on main before through no change of ours. During a
+# release that means a toolchain bump can fail the tag build *after* the tag
+# has been pushed.
+#
+# Bump this in its own PR so toolchain drift shows up as a green/red signal
+# rather than as a surprise inside an unrelated change.
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
There is no `rust-toolchain.toml` in the repo and CI resolves `dtolnay/rust-toolchain@stable`, so a
new stable release can fail CI through no change of ours — which has happened on `main` before.

During a release that's worse than an annoyance: the toolchain can move between pushing a tag and
the tag build running, failing it after the tag already exists.

Pinning makes the toolchain an explicit, reviewable input. Bump it in its own PR so drift shows up
as a green/red signal rather than as a surprise buried inside an unrelated diff.

One file. `cargo check --workspace --all-targets --locked` passes.