### PR TITLE
fix(plugin): resolve the engine handle per call so the GUI survives a reload

### DIFF
--- a/rustortion-plugin/src/backend.rs
+++ b/rustortion-plugin/src/backend.rs
@@ -13,7 +13,6 @@ use rustortion_ui::backend::{Capabilities, ExternalEvent, ParamBackend};
 use crate::SharedState;
 use crate::params::RustortionParams;
 pub struct PluginBackend {
-    engine_handle: EngineHandle,
     params: Arc<RustortionParams>,
     context: Arc<dyn GuiContext>,
     ir_loader: Option<Arc<IrLoader>>,
@@ -24,7 +23,6 @@ pub struct PluginBackend {
 
 impl PluginBackend {
     pub fn new(
-        engine_handle: EngineHandle,
         params: Arc<RustortionParams>,
         context: Arc<dyn GuiContext>,
         ir_loader: Option<Arc<IrLoader>>,
@@ -32,7 +30,6 @@ impl PluginBackend {
         sample_rate: f32,
     ) -> Self {
         Self {
-            engine_handle,
             params,
             context,
             ir_loader,
@@ -40,6 +37,20 @@ impl PluginBackend {
             capabilities: Capabilities::plugin(),
             sample_rate,
         }
+    }
+
+    /// The handle for the engine that is running *right now*.
+    ///
+    /// Deliberately resolved per call rather than cached. `deactivate()` drops
+    /// the engine — which drops the receiving end of the channel — and a
+    /// subsequent `initialize()` builds a new engine with a new channel. A
+    /// handle cloned when the editor opened would still point at the old,
+    /// disconnected channel, so every GUI edit would be silently discarded
+    /// while audio kept flowing through the new engine. That is exactly what
+    /// happens when a host's enable/disable toggle is used with the editor
+    /// open, and it is why this returns an `Option` instead of holding a field.
+    fn engine(&self) -> Option<EngineHandle> {
+        self.shared_state.engine_handle.lock().ok()?.clone()
     }
 
     /// Read DAW-persisted chain state (from `#[persist]` field).
@@ -74,13 +85,17 @@ impl PluginBackend {
 
 impl ParamBackend for PluginBackend {
     fn set_parameter(&self, stage_idx: usize, name: &'static str, value: f32) {
-        self.engine_handle.set_parameter(stage_idx, name, value);
+        if let Some(engine) = self.engine() {
+            engine.set_parameter(stage_idx, name, value);
+        }
     }
 
     fn rebuild_stage(&self, stage_idx: usize, config: &StageConfig) {
         let sr = self.effective_sample_rate();
         let runtime_stage = config.to_runtime(sr);
-        self.engine_handle.replace_stage(stage_idx, runtime_stage);
+        if let Some(engine) = self.engine() {
+            engine.replace_stage(stage_idx, runtime_stage);
+        }
     }
 
     fn set_amp_chain(&self, stages: &[StageConfig]) {
@@ -94,35 +109,48 @@ impl ParamBackend for PluginBackend {
                 chain.set_bypassed(i, true);
             }
         }
-        self.engine_handle.set_amp_chain(chain);
+        if let Some(engine) = self.engine() {
+            engine.set_amp_chain(chain);
+        }
     }
 
     fn set_bypass(&self, stage_idx: usize, bypassed: bool) {
-        self.engine_handle.set_stage_bypassed(stage_idx, bypassed);
+        if let Some(engine) = self.engine() {
+            engine.set_stage_bypassed(stage_idx, bypassed);
+        }
     }
 
     fn add_stage(&self, idx: usize, config: &StageConfig) {
         let sr = self.effective_sample_rate();
         let runtime_stage = config.to_runtime(sr);
-        self.engine_handle.add_stage(idx, runtime_stage);
+        if let Some(engine) = self.engine() {
+            engine.add_stage(idx, runtime_stage);
+        }
     }
 
     fn remove_stage(&self, idx: usize) {
-        self.engine_handle.remove_stage(idx);
+        if let Some(engine) = self.engine() {
+            engine.remove_stage(idx);
+        }
     }
 
     fn swap_stages(&self, a: usize, b: usize) {
-        self.engine_handle.swap_stages(a, b);
+        if let Some(engine) = self.engine() {
+            engine.swap_stages(a, b);
+        }
     }
 
     fn set_ir(&self, name: &str) {
         let Some(loader) = &self.ir_loader else {
             return;
         };
+        let Some(engine) = self.engine() else {
+            return;
+        };
         // Try embedded factory IR first
         if let Some(bytes) = crate::factory::get_factory_ir(name) {
             crate::ir_helper::load_and_set_ir_from_bytes(
-                &self.engine_handle,
+                &engine,
                 loader,
                 name,
                 &bytes,
@@ -130,18 +158,22 @@ impl ParamBackend for PluginBackend {
             );
         } else {
             // Fall back to filesystem (user-added IRs)
-            crate::ir_helper::load_and_set_ir(&self.engine_handle, loader, name, self.sample_rate);
+            crate::ir_helper::load_and_set_ir(&engine, loader, name, self.sample_rate);
         }
     }
 
     fn set_ir_bypass(&self, bypassed: bool) {
-        self.engine_handle.set_ir_bypass(bypassed);
+        if let Some(engine) = self.engine() {
+            engine.set_ir_bypass(bypassed);
+        }
         let param = &self.params.ir_bypass;
         self.notify_host_param_changed(param.as_ptr(), param.preview_normalized(bypassed));
     }
 
     fn set_ir_gain(&self, gain: f32) {
-        self.engine_handle.set_ir_gain(gain);
+        if let Some(engine) = self.engine() {
+            engine.set_ir_gain(gain);
+        }
         let param = &self.params.ir_gain;
         self.notify_host_param_changed(param.as_ptr(), param.preview_normalized(gain));
     }
@@ -165,7 +197,9 @@ impl ParamBackend for PluginBackend {
         } else {
             None
         };
-        self.engine_handle.set_input_filters(hp, lp);
+        if let Some(engine) = self.engine() {
+            engine.set_input_filters(hp, lp);
+        }
 
         // Sync filter params to host
         let p = &self.params.hp_enabled;
@@ -179,7 +213,9 @@ impl ParamBackend for PluginBackend {
     }
 
     fn set_pitch_shift(&self, semitones: i32) {
-        self.engine_handle.set_pitch_shift(semitones);
+        if let Some(engine) = self.engine() {
+            engine.set_pitch_shift(semitones);
+        }
         let param = &self.params.pitch_shift;
         self.notify_host_param_changed(param.as_ptr(), param.preview_normalized(semitones));
     }

--- a/rustortion-plugin/src/backend.rs
+++ b/rustortion-plugin/src/backend.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use nih_plug::prelude::{GuiContext, Param};
 use rustortion_core::amp::chain::AmplifierChain;
@@ -12,45 +13,85 @@ use rustortion_ui::backend::{Capabilities, ExternalEvent, ParamBackend};
 
 use crate::SharedState;
 use crate::params::RustortionParams;
+
+/// GUI-side driver for the plugin's engine.
+///
+/// Holds **no** snapshot of engine state. Everything the engine owns — the
+/// message channel, the IR loader, the sample rate — is resolved from
+/// [`SharedState`] on each call.
+///
+/// That is not a style preference. `deactivate()` drops the engine (and with
+/// it the receiving end of the channel) and nulls the shared slots; a
+/// subsequent `initialize()` rebuilds all of them, possibly at a different
+/// sample rate. nih-plug also permits `initialize()` to run repeatedly with no
+/// intervening `deactivate()` while restoring state. Anything captured when the
+/// editor window opened outlives every one of those transitions, and the editor
+/// window is not reopened in between — so a captured value is a value that goes
+/// quietly wrong while the UI keeps looking alive.
 pub struct PluginBackend {
     params: Arc<RustortionParams>,
     context: Arc<dyn GuiContext>,
-    ir_loader: Option<Arc<IrLoader>>,
     shared_state: Arc<SharedState>,
     capabilities: Capabilities,
-    sample_rate: f32,
 }
 
 impl PluginBackend {
     pub fn new(
         params: Arc<RustortionParams>,
         context: Arc<dyn GuiContext>,
-        ir_loader: Option<Arc<IrLoader>>,
         shared_state: Arc<SharedState>,
-        sample_rate: f32,
     ) -> Self {
         Self {
             params,
             context,
-            ir_loader,
             shared_state,
             capabilities: Capabilities::plugin(),
-            sample_rate,
         }
     }
 
-    /// The handle for the engine that is running *right now*.
-    ///
-    /// Deliberately resolved per call rather than cached. `deactivate()` drops
-    /// the engine — which drops the receiving end of the channel — and a
-    /// subsequent `initialize()` builds a new engine with a new channel. A
-    /// handle cloned when the editor opened would still point at the old,
-    /// disconnected channel, so every GUI edit would be silently discarded
-    /// while audio kept flowing through the new engine. That is exactly what
-    /// happens when a host's enable/disable toggle is used with the editor
-    /// open, and it is why this returns an `Option` instead of holding a field.
+    /// The handle for the engine that is running *right now*, or `None` between
+    /// `deactivate()` and the next `initialize()`.
     fn engine(&self) -> Option<EngineHandle> {
         self.shared_state.engine_handle.lock().ok()?.clone()
+    }
+
+    /// The IR loader belonging to the current engine.
+    ///
+    /// Rebuilt by `initialize()` bound to the then-current sample rate, since
+    /// the loader is what resamples IRs on the way in. A loader from a previous
+    /// activation resamples to the wrong rate; one captured while the plugin
+    /// was inactive is `None` forever and silently disables IR selection.
+    fn ir_loader(&self) -> Option<Arc<IrLoader>> {
+        self.shared_state.ir_loader.lock().ok()?.clone()
+    }
+
+    /// The host's sample rate, or `None` before the first `initialize()`.
+    ///
+    /// The shared slot starts at zero, and a host may open the editor before it
+    /// activates the plugin. Building a stage at 0 Hz is not merely inaccurate:
+    /// `FilterStage`'s alpha divides by the rate, so a lowpass comes out with a
+    /// NaN coefficient. Callers bail rather than hand that to a live engine.
+    fn host_sample_rate(&self) -> Option<f32> {
+        let sr = f32::from_bits(self.shared_state.sample_rate.load(Ordering::Relaxed));
+        (sr.is_finite() && sr > 0.0).then_some(sr)
+    }
+
+    /// Engine handle plus the effective rate to build stages at.
+    ///
+    /// Both or neither: a stage built at the wrong rate is no better than one
+    /// that never arrives, and it is harder to notice.
+    fn engine_with_effective_rate(&self) -> Option<(EngineHandle, f32)> {
+        Some((self.engine()?, self.effective_sample_rate()?))
+    }
+
+    /// Note a GUI edit that could not be delivered.
+    ///
+    /// No engine is a legitimate state, not an error, so this is `debug` rather
+    /// than `warn`. But it is also how the stale-handle bug stayed hidden for
+    /// four months: every dropped edit went into a log line nobody was running
+    /// with. Leave a trail for the next `NIH_LOG=debug` session.
+    fn note_dropped_edit(what: &str) {
+        log::debug!("GUI edit '{what}' dropped: no active engine");
     }
 
     /// Read DAW-persisted chain state (from `#[persist]` field).
@@ -62,12 +103,12 @@ impl PluginBackend {
     /// not the requested one. This ensures chain rebuilds match the current
     /// sampler state.
     #[allow(clippy::cast_precision_loss)]
-    fn effective_sample_rate(&self) -> f32 {
+    fn effective_sample_rate(&self) -> Option<f32> {
         let active = self
             .shared_state
             .active_oversampling
-            .load(std::sync::atomic::Ordering::Relaxed);
-        self.sample_rate * active as f32
+            .load(Ordering::Relaxed);
+        Some(self.host_sample_rate()? * active as f32)
     }
 
     /// Notify the host that a parameter value changed from the GUI.
@@ -85,21 +126,28 @@ impl PluginBackend {
 
 impl ParamBackend for PluginBackend {
     fn set_parameter(&self, stage_idx: usize, name: &'static str, value: f32) {
-        if let Some(engine) = self.engine() {
-            engine.set_parameter(stage_idx, name, value);
-        }
+        let Some(engine) = self.engine() else {
+            Self::note_dropped_edit("set_parameter");
+            return;
+        };
+        engine.set_parameter(stage_idx, name, value);
     }
 
     fn rebuild_stage(&self, stage_idx: usize, config: &StageConfig) {
-        let sr = self.effective_sample_rate();
-        let runtime_stage = config.to_runtime(sr);
-        if let Some(engine) = self.engine() {
-            engine.replace_stage(stage_idx, runtime_stage);
-        }
+        // Resolve before building: with no engine the stage would be allocated
+        // only to be dropped, and with no rate it would be built wrong.
+        let Some((engine, sr)) = self.engine_with_effective_rate() else {
+            Self::note_dropped_edit("rebuild_stage");
+            return;
+        };
+        engine.replace_stage(stage_idx, config.to_runtime(sr));
     }
 
     fn set_amp_chain(&self, stages: &[StageConfig]) {
-        let sr = self.effective_sample_rate();
+        let Some((engine, sr)) = self.engine_with_effective_rate() else {
+            Self::note_dropped_edit("set_amp_chain");
+            return;
+        };
         let mut chain = AmplifierChain::new();
         for cfg in stages {
             chain.add_stage(cfg.to_runtime(sr));
@@ -109,62 +157,64 @@ impl ParamBackend for PluginBackend {
                 chain.set_bypassed(i, true);
             }
         }
-        if let Some(engine) = self.engine() {
-            engine.set_amp_chain(chain);
-        }
+        engine.set_amp_chain(chain);
     }
 
     fn set_bypass(&self, stage_idx: usize, bypassed: bool) {
-        if let Some(engine) = self.engine() {
-            engine.set_stage_bypassed(stage_idx, bypassed);
-        }
+        let Some(engine) = self.engine() else {
+            Self::note_dropped_edit("set_bypass");
+            return;
+        };
+        engine.set_stage_bypassed(stage_idx, bypassed);
     }
 
     fn add_stage(&self, idx: usize, config: &StageConfig) {
-        let sr = self.effective_sample_rate();
-        let runtime_stage = config.to_runtime(sr);
-        if let Some(engine) = self.engine() {
-            engine.add_stage(idx, runtime_stage);
-        }
+        let Some((engine, sr)) = self.engine_with_effective_rate() else {
+            Self::note_dropped_edit("add_stage");
+            return;
+        };
+        engine.add_stage(idx, config.to_runtime(sr));
     }
 
     fn remove_stage(&self, idx: usize) {
-        if let Some(engine) = self.engine() {
-            engine.remove_stage(idx);
-        }
+        let Some(engine) = self.engine() else {
+            Self::note_dropped_edit("remove_stage");
+            return;
+        };
+        engine.remove_stage(idx);
     }
 
     fn swap_stages(&self, a: usize, b: usize) {
-        if let Some(engine) = self.engine() {
-            engine.swap_stages(a, b);
-        }
+        let Some(engine) = self.engine() else {
+            Self::note_dropped_edit("swap_stages");
+            return;
+        };
+        engine.swap_stages(a, b);
     }
 
     fn set_ir(&self, name: &str) {
-        let Some(loader) = &self.ir_loader else {
-            return;
-        };
-        let Some(engine) = self.engine() else {
+        // The IR runs after downsampling, so it is built at the host rate, not
+        // the oversampled one.
+        let (Some(loader), Some(engine), Some(sr)) =
+            (self.ir_loader(), self.engine(), self.host_sample_rate())
+        else {
+            Self::note_dropped_edit("set_ir");
             return;
         };
         // Try embedded factory IR first
         if let Some(bytes) = crate::factory::get_factory_ir(name) {
-            crate::ir_helper::load_and_set_ir_from_bytes(
-                &engine,
-                loader,
-                name,
-                &bytes,
-                self.sample_rate,
-            );
+            crate::ir_helper::load_and_set_ir_from_bytes(&engine, &loader, name, &bytes, sr);
         } else {
             // Fall back to filesystem (user-added IRs)
-            crate::ir_helper::load_and_set_ir(&engine, loader, name, self.sample_rate);
+            crate::ir_helper::load_and_set_ir(&engine, &loader, name, sr);
         }
     }
 
     fn set_ir_bypass(&self, bypassed: bool) {
         if let Some(engine) = self.engine() {
             engine.set_ir_bypass(bypassed);
+        } else {
+            Self::note_dropped_edit("set_ir_bypass");
         }
         let param = &self.params.ir_bypass;
         self.notify_host_param_changed(param.as_ptr(), param.preview_normalized(bypassed));
@@ -173,32 +223,29 @@ impl ParamBackend for PluginBackend {
     fn set_ir_gain(&self, gain: f32) {
         if let Some(engine) = self.engine() {
             engine.set_ir_gain(gain);
+        } else {
+            Self::note_dropped_edit("set_ir_gain");
         }
         let param = &self.params.ir_gain;
         self.notify_host_param_changed(param.as_ptr(), param.preview_normalized(gain));
     }
 
     fn set_input_filter(&self, filter: &InputFilterConfig) {
-        let hp: Option<Box<dyn Stage>> = if filter.hp_enabled {
-            Some(Box::new(FilterStage::new(
-                FilterType::Highpass,
-                filter.hp_cutoff,
-                self.sample_rate,
-            )))
-        } else {
-            None
-        };
-        let lp: Option<Box<dyn Stage>> = if filter.lp_enabled {
-            Some(Box::new(FilterStage::new(
-                FilterType::Lowpass,
-                filter.lp_cutoff,
-                self.sample_rate,
-            )))
-        } else {
-            None
-        };
-        if let Some(engine) = self.engine() {
+        // Input filters sit ahead of the upsampler, so they too are built at the
+        // host rate. Host param sync below happens either way — those are the
+        // host's parameters, and they stay valid with no engine attached.
+        if let (Some(engine), Some(sr)) = (self.engine(), self.host_sample_rate()) {
+            let hp: Option<Box<dyn Stage>> = filter.hp_enabled.then(|| {
+                Box::new(FilterStage::new(FilterType::Highpass, filter.hp_cutoff, sr))
+                    as Box<dyn Stage>
+            });
+            let lp: Option<Box<dyn Stage>> = filter.lp_enabled.then(|| {
+                Box::new(FilterStage::new(FilterType::Lowpass, filter.lp_cutoff, sr))
+                    as Box<dyn Stage>
+            });
             engine.set_input_filters(hp, lp);
+        } else {
+            Self::note_dropped_edit("set_input_filter");
         }
 
         // Sync filter params to host
@@ -215,6 +262,8 @@ impl ParamBackend for PluginBackend {
     fn set_pitch_shift(&self, semitones: i32) {
         if let Some(engine) = self.engine() {
             engine.set_pitch_shift(semitones);
+        } else {
+            Self::note_dropped_edit("set_pitch_shift");
         }
         let param = &self.params.pitch_shift;
         self.notify_host_param_changed(param.as_ptr(), param.preview_normalized(semitones));
@@ -234,11 +283,11 @@ impl ParamBackend for PluginBackend {
         );
         self.shared_state
             .requested_oversampling
-            .store(factor, std::sync::atomic::Ordering::Relaxed);
+            .store(factor, Ordering::Relaxed);
         // Sync to params for DAW project persistence
         self.params
             .oversampling_factor
-            .store(factor, std::sync::atomic::Ordering::Relaxed);
+            .store(factor, Ordering::Relaxed);
         // Mark DAW session dirty so the new value is saved with the project.
         // #[persist] fields are serialized passively and don't trigger a save.
         let param = &self.params.preset_idx;
@@ -246,16 +295,18 @@ impl ParamBackend for PluginBackend {
         self.notify_host_param_changed(param.as_ptr(), current);
     }
 
+    /// Zero until the host activates the plugin. Read live so the NAM stage's
+    /// rate-mismatch badge reflects the engine that is actually running.
     fn sample_rate(&self) -> u32 {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let sr = self.sample_rate as u32;
+        let sr = self.host_sample_rate().unwrap_or(0.0) as u32;
         sr
     }
 
     fn oversampling_factor(&self) -> u32 {
         self.shared_state
             .requested_oversampling
-            .load(std::sync::atomic::Ordering::Relaxed)
+            .load(Ordering::Relaxed)
     }
 
     fn capabilities(&self) -> &Capabilities {
@@ -265,7 +316,7 @@ impl ParamBackend for PluginBackend {
     fn get_available_irs(&self) -> Vec<String> {
         let mut names = crate::factory::factory_ir_names();
         // Also include any user IRs from filesystem
-        if let Some(loader) = &self.ir_loader {
+        if let Some(loader) = self.ir_loader() {
             for name in loader.available_ir_names() {
                 if !names.contains(&name) {
                     names.push(name);

--- a/rustortion-plugin/src/editor.rs
+++ b/rustortion-plugin/src/editor.rs
@@ -61,28 +61,19 @@ impl Editor for PluginEditor {
         parent: nih_plug::editor::ParentWindowHandle,
         context: Arc<dyn GuiContext>,
     ) -> Box<dyn std::any::Any + Send> {
-        // NOTE: the engine handle is deliberately NOT captured here. It is
-        // resolved per call in `PluginBackend`, because a host enable/disable
-        // cycle replaces the engine (and its channel) underneath us.
-        let ir_loader = self
-            .shared_state
-            .ir_loader
-            .lock()
-            .ok()
-            .and_then(|g| g.clone());
-        let sample_rate = f32::from_bits(
-            self.shared_state
-                .sample_rate
-                .load(std::sync::atomic::Ordering::Relaxed),
-        );
+        // NOTE: no engine state is captured here — not the engine handle, not
+        // the IR loader, not the sample rate. All three are owned by the engine,
+        // all three are replaced by a `deactivate()`/`initialize()` cycle, and
+        // this window outlives that cycle. `PluginBackend` resolves each of them
+        // from `SharedState` per call instead. `restored_preset_idx` is safe to
+        // read once: it is the DAW's restored value at open time, not engine
+        // state.
         let restored_preset_idx = self.params.preset_idx.value();
 
         let flags = PluginAppFlags {
             params: self.params.clone(),
             context,
             shared_state: self.shared_state.clone(),
-            ir_loader,
-            sample_rate,
             restored_preset_idx,
         };
 
@@ -130,8 +121,6 @@ struct PluginAppFlags {
     params: Arc<RustortionParams>,
     context: Arc<dyn GuiContext>,
     shared_state: Arc<crate::SharedState>,
-    ir_loader: Option<Arc<rustortion_core::ir::loader::IrLoader>>,
-    sample_rate: f32,
     restored_preset_idx: i32,
 }
 
@@ -146,13 +135,7 @@ impl iced_baseview::Application for PluginApp {
     type Flags = PluginAppFlags;
 
     fn new(flags: Self::Flags) -> (Self, iced_baseview::Task<Self::Message>) {
-        let backend = PluginBackend::new(
-            flags.params,
-            flags.context,
-            flags.ir_loader,
-            flags.shared_state.clone(),
-            flags.sample_rate,
-        );
+        let backend = PluginBackend::new(flags.params, flags.context, flags.shared_state.clone());
 
         let available_irs = backend.get_available_irs();
 

--- a/rustortion-plugin/src/editor.rs
+++ b/rustortion-plugin/src/editor.rs
@@ -61,13 +61,9 @@ impl Editor for PluginEditor {
         parent: nih_plug::editor::ParentWindowHandle,
         context: Arc<dyn GuiContext>,
     ) -> Box<dyn std::any::Any + Send> {
-        // Gather engine state for the backend
-        let engine_handle = self
-            .shared_state
-            .engine_handle
-            .lock()
-            .ok()
-            .and_then(|g| g.clone());
+        // NOTE: the engine handle is deliberately NOT captured here. It is
+        // resolved per call in `PluginBackend`, because a host enable/disable
+        // cycle replaces the engine (and its channel) underneath us.
         let ir_loader = self
             .shared_state
             .ir_loader
@@ -85,7 +81,6 @@ impl Editor for PluginEditor {
             params: self.params.clone(),
             context,
             shared_state: self.shared_state.clone(),
-            engine_handle,
             ir_loader,
             sample_rate,
             restored_preset_idx,
@@ -135,21 +130,13 @@ struct PluginAppFlags {
     params: Arc<RustortionParams>,
     context: Arc<dyn GuiContext>,
     shared_state: Arc<crate::SharedState>,
-    engine_handle: Option<rustortion_core::audio::engine::EngineHandle>,
     ir_loader: Option<Arc<rustortion_core::ir::loader::IrLoader>>,
     sample_rate: f32,
     restored_preset_idx: i32,
 }
 
 struct PluginApp {
-    /// `None` when the editor was opened while the plugin is inactive.
-    ///
-    /// `deactivate()` nulls the shared engine handle, so a host that opens the
-    /// editor on an inactive instance leaves us with nothing to drive. That is a
-    /// legitimate host behaviour, not a bug, so we render a placeholder rather
-    /// than panicking — a panic here runs on the host's UI thread and takes the
-    /// whole DAW down with it.
-    shared: Option<SharedApp<PluginBackend>>,
+    shared: SharedApp<PluginBackend>,
 }
 
 impl iced_baseview::Application for PluginApp {
@@ -159,16 +146,7 @@ impl iced_baseview::Application for PluginApp {
     type Flags = PluginAppFlags;
 
     fn new(flags: Self::Flags) -> (Self, iced_baseview::Task<Self::Message>) {
-        let Some(engine_handle) = flags.engine_handle else {
-            nih_plug::nih_log!(
-                "Editor opened without an engine handle (plugin inactive); \
-                 showing placeholder"
-            );
-            return (Self { shared: None }, iced_baseview::Task::none());
-        };
-
         let backend = PluginBackend::new(
-            engine_handle,
             flags.params,
             flags.context,
             flags.ir_loader,
@@ -241,20 +219,11 @@ impl iced_baseview::Application for PluginApp {
             |stages| iced_baseview::Task::done(Message::SetStages(stages)),
         );
 
-        (
-            Self {
-                shared: Some(shared),
-            },
-            init_task,
-        )
+        (Self { shared }, init_task)
     }
 
     fn update(&mut self, message: Self::Message) -> iced_baseview::Task<Self::Message> {
-        let Some(shared) = self.shared.as_mut() else {
-            return iced_baseview::Task::none();
-        };
-
-        match shared.update(message) {
+        match self.shared.update(message) {
             UpdateResult::Handled(task) => task,
             UpdateResult::Unhandled(_msg) => {
                 // Standalone-only messages (Settings, Midi, Tuner, Recording)
@@ -267,9 +236,7 @@ impl iced_baseview::Application for PluginApp {
     fn view(
         &self,
     ) -> iced_baseview::Element<'_, Self::Message, Self::Theme, iced_baseview::Renderer> {
-        self.shared
-            .as_ref()
-            .map_or_else(inactive_view, SharedApp::view)
+        self.shared.view()
     }
 
     fn theme(&self) -> Self::Theme {
@@ -280,29 +247,6 @@ impl iced_baseview::Application for PluginApp {
         &self,
         _window_subs: &mut iced_baseview::WindowSubs<Self::Message>,
     ) -> iced_baseview::futures::Subscription<Self::Message> {
-        self.shared.as_ref().map_or_else(
-            iced_baseview::futures::Subscription::none,
-            SharedApp::subscription,
-        )
+        self.shared.subscription()
     }
-}
-
-/// Placeholder shown when the editor is opened on an inactive plugin instance.
-fn inactive_view<'a>()
--> iced_baseview::Element<'a, Message, iced_baseview::Theme, iced_baseview::Renderer> {
-    use iced_baseview::widget::{Column, container, text};
-
-    let t = rustortion_ui::i18n::translations();
-
-    container(
-        Column::with_children(vec![
-            text(t.plugin_inactive_title).size(20).into(),
-            text(t.plugin_inactive_hint).size(14).into(),
-        ])
-        .spacing(8)
-        .align_x(iced_baseview::Center),
-    )
-    .center_x(iced_baseview::Fill)
-    .center_y(iced_baseview::Fill)
-    .into()
 }

--- a/rustortion-ui/src/i18n/mod.rs
+++ b/rustortion-ui/src/i18n/mod.rs
@@ -268,10 +268,6 @@ pub struct Translations {
     // Peak meter / status
     pub xruns: &'static str,
     pub cpu: &'static str,
-
-    // Plugin editor
-    pub plugin_inactive_title: &'static str,
-    pub plugin_inactive_hint: &'static str,
 }
 
 impl Translations {
@@ -481,10 +477,6 @@ pub static EN: Translations = Translations {
     // Peak meter / status
     xruns: "xruns",
     cpu: "CPU",
-
-    // Plugin editor
-    plugin_inactive_title: "Plugin not active",
-    plugin_inactive_hint: "Enable the plugin in your host, then reopen this window.",
 };
 
 pub static ZH_CN: Translations = Translations {
@@ -685,8 +677,4 @@ pub static ZH_CN: Translations = Translations {
     // Peak meter / status
     xruns: "欠载",
     cpu: "CPU",
-
-    // Plugin editor
-    plugin_inactive_title: "插件未激活",
-    plugin_inactive_hint: "请在宿主中启用插件，然后重新打开此窗口。",
 };


### PR DESCRIPTION
Found while dogfooding the merged v0.3.0 work in Ardour.

## Symptom

Toggle the plugin off and on in the host, and the **entire editor goes inert** — knobs,
add/remove stage, IR selection, NAM model change all do nothing. Audio keeps processing
normally the whole time, so nothing looks wrong. Preset changes are the one thing that
still works.

Reported symptoms, all explained by the single cause below:

| Observation | |
|---|---|
| Amp is audible and responds to playing | ✅ |
| Knobs do nothing | ❌ |
| Add stage does nothing | ❌ |
| IR change does nothing | ❌ |
| NAM model change does nothing | ❌ |
| Preset change works | ✅ |
| Standalone unaffected | ✅ |
| Fixed by removing and re-adding the plugin | ✅ |

## Root cause

`PluginBackend` stored an `EngineHandle` **cloned once**, when the editor window spawned
(`editor.rs`, `spawn()`).

A host enable/disable cycle runs:

1. `deactivate()` — drops the `Engine`, and with it the receiving end of the channel, so
   that channel is now **disconnected**. Also nulls `shared.engine_handle`.
2. `initialize()` — builds a **new** `Engine` with a **new** channel.

Audio then flows through the new engine, while the editor keeps sending into the old,
disconnected one. Every message lands in `try_send`'s error arm:

```rust
self.engine_sender.try_send(message).unwrap_or_else(|e| {
    error!("Failed to send engine message: {e}");
});
```

…which logs and discards. Silent from the user's side unless they happen to be running with
`NIH_LOG` set.

Preset changes were the exception because preset loading is the one path that reads
`shared.engine_handle` **live** on each invocation (`lib.rs:471`) instead of caching it.

## Fix

`PluginBackend` no longer holds a handle. It resolves one per call from `SharedState`,
exactly as the preset path already did.

Deleting the field rather than refreshing it is deliberate: it makes this class of staleness
impossible by construction instead of by convention.

## Also removes the "plugin inactive" placeholder from #268

With per-call resolution that placeholder was actively harmful — an editor opened while the
plugin was disabled would have stayed on the placeholder **even after the plugin was
re-enabled**, which is the same staleness bug wearing a different hat.

The panic it was added to guard (P1-4) is gone by a better route: nothing unwraps a handle at
construction time any more, so there is nothing left to panic on. Its i18n keys are removed
with it.

## Notes

- **This is REV-8**, which was cut from the v0.3.0 gate as P2 work. Worth reclassifying: it is
  reachable through an ordinary host control, it silently disables the whole UI, and it was hit
  within minutes of the first real DAW test.
- **Not a regression from #268-#271.** `spawn()` has cloned the handle this way all along.
- **No automated regression test.** Reproducing this needs a plugin activation lifecycle, and
  `PluginBackend::new` requires a `GuiContext`, so there is no harness for it. The deleted field
  is the structural guarantee instead. Flagging rather than implying coverage that does not exist.

`make lint` clean, 260 tests passing. Verified by hand in Ardour against the reported repro.