### PR TITLE
fix(preset): stop non-ASCII preset names from colliding on disk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,14 @@ There are **12** registered stages. The `gui_stage_registry!` macro in
 
 ## Pitfalls
 
-- **Preset files** — one JSON per preset in `~/.config/rustortion/presets/`. Filenames are
-  percent-encoded (`[A-Za-z0-9-_]` kept verbatim), but a preset is identified by the `name` field
-  *inside* the JSON — `Manager` remembers the path each preset was loaded from so saves/deletes
-  reuse legacy filenames. Saves are still not atomic (`fs::write`) and save/delete failures are
-  only logged, never surfaced in the UI (REV-7 remainder).
+- **Preset files** — one JSON per preset in `preset_dir`, which defaults to `./presets` (CWD-relative,
+  and the *shipped* `presets/` is that live writable directory). `~/.config/rustortion/` holds
+  `settings.json`, not presets. Filenames are percent-encoded (`[A-Za-z0-9-_]` kept verbatim), but a
+  preset is identified by the `name` field *inside* the JSON — `Manager` remembers the path each
+  preset was loaded from so saves/deletes reuse legacy filenames, and `path_for` refuses any
+  candidate another preset already occupies (falling back to a digest-suffixed stem). Saves are
+  still not atomic (`fs::write`) and save/delete failures are only logged, never surfaced in the UI
+  (REV-7 remainder).
 - **NAM models** (`.nam`, WaveNet + LSTM via `nam-rs`) load from a user folder with rescan, into a
   process-global registry; stages resolve them **by name**. No rfd file-picker — rfd/gtk3 breaks CI.
 - **IR files** live in `impulse_responses/` and `~/.config/rustortion/impulse_responses/`; loading

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,11 @@ There are **12** registered stages. The `gui_stage_registry!` macro in
 
 ## Pitfalls
 
-- **Preset files** — one JSON per preset in `~/.config/rustortion/presets/`. Saves are not atomic
-  and filenames collide on non-ASCII names (REV-7); don't build on the current behavior.
+- **Preset files** — one JSON per preset in `~/.config/rustortion/presets/`. Filenames are
+  percent-encoded (`[A-Za-z0-9-_]` kept verbatim), but a preset is identified by the `name` field
+  *inside* the JSON — `Manager` remembers the path each preset was loaded from so saves/deletes
+  reuse legacy filenames. Saves are still not atomic (`fs::write`) and save/delete failures are
+  only logged, never surfaced in the UI (REV-7 remainder).
 - **NAM models** (`.nam`, WaveNet + LSTM via `nam-rs`) load from a user folder with rescan, into a
   process-global registry; stages resolve them **by name**. No rfd file-picker — rfd/gtk3 breaks CI.
 - **IR files** live in `impulse_responses/` and `~/.config/rustortion/impulse_responses/`; loading

--- a/rustortion-core/src/preset/manager.rs
+++ b/rustortion-core/src/preset/manager.rs
@@ -114,18 +114,24 @@ impl Manager {
         if self.presets_dir.as_os_str().is_empty() {
             return Err(anyhow::anyhow!("Cannot delete presets in read-only mode"));
         }
-        let path = self.path_for(preset_name);
 
-        if path.exists() {
-            fs::remove_file(&path).context("Failed to delete preset file")?;
+        // Only ever remove a file we positively attributed to this preset when
+        // it was loaded. Deriving a path from the name instead would let
+        // `delete_preset("My_Preset")` delete `My_Preset.json` — which may well
+        // hold a *different* preset named `My Preset` — and report success.
+        let path = self
+            .preset_paths
+            .get(preset_name)
+            .filter(|path| path.exists())
+            .ok_or_else(|| anyhow::anyhow!("Preset file not found: {preset_name}"))?
+            .clone();
 
-            // Reload presets to reflect the deletion
-            self.load_presets()?;
+        fs::remove_file(&path).context("Failed to delete preset file")?;
 
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!("Preset file not found: {preset_name}"))
-        }
+        // Reload presets to reflect the deletion
+        self.load_presets()?;
+
+        Ok(())
     }
 
     pub fn preset_exists(&self, name: &str) -> bool {
@@ -140,20 +146,60 @@ impl Manager {
         self.presets.iter().find(|p| p.name == name)
     }
 
-    /// Resolve the file a preset should be written to (or deleted from).
+    /// Resolve the file a preset should be written to.
     ///
     /// If the preset is already on disk we reuse the exact path it was loaded
     /// from, so presets saved by older versions keep their existing filenames
-    /// and never end up duplicated. Only presets that do not exist yet get a
-    /// freshly encoded filename.
+    /// and never end up duplicated.
+    ///
+    /// A preset we have never seen gets a freshly encoded filename — but only
+    /// if nothing else already occupies it. Encoding is the identity on names
+    /// drawn from `[A-Za-z0-9-_]`, which is exactly the alphabet the old lossy
+    /// scheme emitted, so a *new* preset called `High_Gain` would otherwise
+    /// land on the shipped `High_Gain.json` holding `High Gain` and destroy it.
+    /// When the candidate is taken we fall back to the digest-suffixed stem
+    /// instead. Filenames carry no user-visible identity — the `name` field
+    /// inside the JSON does — so disambiguating silently is strictly
+    /// data-preserving and invisible to the user. Same-*name* overwrites are a
+    /// separate question, gated by the GUI's confirmation prompt.
     fn path_for(&self, preset_name: &str) -> PathBuf {
-        self.preset_paths.get(preset_name).map_or_else(
-            || {
-                self.presets_dir
-                    .join(format!("{}.json", sanitize_filename(preset_name)))
-            },
-            Clone::clone,
-        )
+        if let Some(existing) = self.preset_paths.get(preset_name) {
+            return existing.clone();
+        }
+
+        let candidate = self.file_for_stem(&sanitize_filename(preset_name));
+        if self.is_unoccupied(&candidate) {
+            return candidate;
+        }
+
+        let hashed = hashed_stem(preset_name);
+        let candidate = self.file_for_stem(&hashed);
+        if self.is_unoccupied(&candidate) {
+            return candidate;
+        }
+
+        // The digest stem is taken too — only reachable if some preset is
+        // literally named after it. Walk a counter; every step is still a
+        // deterministic filename. Exhausting the range would need a thousand
+        // such presets, so falling back to the digest stem is unreachable in
+        // practice rather than a silent overwrite waiting to happen.
+        (1..=MAX_DISAMBIGUATION_ATTEMPTS)
+            .map(|n| self.file_for_stem(&format!("{hashed}-{n}")))
+            .find(|path| self.is_unoccupied(path))
+            .unwrap_or(candidate)
+    }
+
+    fn file_for_stem(&self, stem: &str) -> PathBuf {
+        self.presets_dir.join(format!("{stem}.json"))
+    }
+
+    /// Is `path` free for a preset we are about to write?
+    ///
+    /// Callers reach this only after `path_for` has ruled out the preset's own
+    /// file, so anything already on disk belongs to something else — including
+    /// files that failed to parse and so never made it into `preset_paths`.
+    fn is_unoccupied(&self, path: &Path) -> bool {
+        !path.exists() && !self.preset_paths.values().any(|owned| owned == path)
     }
 }
 
@@ -263,6 +309,11 @@ const MAX_STEM_BYTES: usize = 200;
 /// `'-'` plus 16 hex digits, appended to truncated stems.
 const HASH_SUFFIX_BYTES: usize = 17;
 
+/// How far `Manager::path_for` will count when even the digest-suffixed stem is
+/// already occupied. Reaching the end needs a preset named after the digest
+/// stem *and* a thousand more named after its numbered variants.
+const MAX_DISAMBIGUATION_ATTEMPTS: u32 = 1000;
+
 const HEX_DIGITS: [u8; 16] = *b"0123456789ABCDEF";
 
 /// 64-bit FNV-1a.
@@ -303,16 +354,34 @@ fn percent_encode(name: &str, budget: usize) -> (String, bool) {
     (out, false)
 }
 
-/// Turn a preset name into a filename stem that is unique to that name.
+/// A readable prefix of `name` plus a digest of the whole of it, short enough
+/// to survive the filesystem's per-component byte limit.
 ///
-/// Percent-encoding every byte outside `[A-Za-z0-9-_]` is injective, so two
-/// different preset names can never land on the same file. It is also stable
-/// and reversible, and — crucially for existing installs — it is the identity
-/// on names that only use the allowed characters, which is exactly the set of
-/// names the old scheme left untouched.
+/// Used both for pathologically long names and, by `Manager::path_for`, to step
+/// aside when the plain encoding is already occupied.
+fn hashed_stem(name: &str) -> String {
+    let (stem, _) = percent_encode(name, MAX_STEM_BYTES - HASH_SUFFIX_BYTES);
+    let hash = stable_hash(name.as_bytes());
+    format!("{stem}-{hash:016x}")
+}
+
+/// Turn a preset name into a filename stem.
 ///
-/// The old scheme mapped everything else to `_`, which collapsed *every*
-/// non-ASCII name (a whole locale's worth of preset names) onto a single file.
+/// Percent-encoding every byte outside `[A-Za-z0-9-_]` is stable, reversible,
+/// and — crucially for existing installs — the identity on names that only use
+/// the allowed characters, which is exactly the set of names the old scheme
+/// left untouched. The old scheme mapped everything else to `_`, which
+/// collapsed *every* non-ASCII name (a whole locale's worth of preset names)
+/// onto a single file.
+///
+/// **The mapping is not injective.** It is injective on names short enough to
+/// encode whole, but longer names are truncated and digest-suffixed, and `-`
+/// and `0-9a-f` are all unreserved — so the suffixed stem is itself a valid
+/// identity encoding of some other, shorter name. `"x".repeat(500)` and a
+/// preset named literally `xxx…x-b6822c71b0501b75` produce the same stem.
+/// Callers must not assume distinct names yield distinct filenames;
+/// `Manager::path_for` checks that its candidate is unoccupied before handing
+/// it out, which is what actually keeps two presets off one file.
 fn sanitize_filename(name: &str) -> String {
     if name.is_empty() {
         // The encoder never emits a bare `%` — every `%` it writes is followed
@@ -321,16 +390,11 @@ fn sanitize_filename(name: &str) -> String {
     }
 
     let (encoded, truncated) = percent_encode(name, MAX_STEM_BYTES);
-    if !truncated {
-        return encoded;
+    if truncated {
+        hashed_stem(name)
+    } else {
+        encoded
     }
-
-    // Pathologically long names get a readable prefix plus a digest of the full
-    // name, which keeps distinct names distinct without blowing the filesystem's
-    // per-component byte limit.
-    let (stem, _) = percent_encode(name, MAX_STEM_BYTES - HASH_SUFFIX_BYTES);
-    let hash = stable_hash(name.as_bytes());
-    format!("{stem}-{hash:016x}")
 }
 
 #[cfg(test)]
@@ -349,6 +413,14 @@ mod tests {
             -2,
             InputFilterConfig::default(),
         )
+    }
+
+    fn json_files(dir: &Path) -> HashSet<PathBuf> {
+        fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("json"))
+            .collect()
     }
 
     /// Existing installs already have files on disk. Any name the old scheme
@@ -428,6 +500,41 @@ mod tests {
         );
     }
 
+    /// The empty name has no encoding of its own, so it gets a stem the encoder
+    /// can never produce. Justified by a comment since the PR that added it,
+    /// but never actually checked.
+    #[test]
+    fn sanitize_filename_handles_the_empty_name() {
+        assert_eq!(sanitize_filename(""), "%");
+        assert_eq!(sanitize_filename("%"), "%25");
+        assert_ne!(sanitize_filename(""), sanitize_filename("%"));
+    }
+
+    /// `stable_hash` is hand-rolled FNV-1a precisely because `DefaultHasher`'s
+    /// algorithm is not stable across Rust releases, and these digests end up in
+    /// filenames. Determinism *within* a process proves nothing about that — pin
+    /// literals so a toolchain that changed them fails here instead of silently
+    /// orphaning every long-named preset.
+    #[test]
+    fn stable_hash_matches_pinned_values() {
+        assert_eq!(stable_hash(b""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(stable_hash(b"rustortion"), 0x79c8_6023_c73e_36c0);
+        assert_eq!(stable_hash("重金属".as_bytes()), 0x980e_d7b0_0cf5_300d);
+        assert_eq!(
+            stable_hash("x".repeat(500).as_bytes()),
+            0xb682_2c71_b050_1b75
+        );
+
+        // ...and the filename that digest produces.
+        assert_eq!(
+            sanitize_filename(&"x".repeat(500)),
+            format!(
+                "{}-b6822c71b0501b75",
+                "x".repeat(MAX_STEM_BYTES - HASH_SUFFIX_BYTES)
+            )
+        );
+    }
+
     #[test]
     fn sanitize_filename_is_deterministic() {
         assert_eq!(sanitize_filename("重金属"), sanitize_filename("重金属"));
@@ -504,6 +611,91 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    /// The path-occupancy hole. `presets/High_Gain.json` ships with the app and
+    /// holds a preset *named* `High Gain`. Encoding is the identity on
+    /// `High_Gain`, so saving a preset under that literal name computed the very
+    /// same path — no dialog, since the overwrite gate compares names — and the
+    /// factory preset was gone.
+    #[test]
+    fn saving_a_name_that_lands_on_another_presets_file_keeps_both() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory_path = dir.path().join("High_Gain.json");
+        fs::write(
+            &factory_path,
+            serde_json::to_string(&preset_named("High Gain")).unwrap(),
+        )
+        .unwrap();
+
+        let mut manager = Manager::new(dir.path()).unwrap();
+        manager.save_preset(&preset_named("High_Gain")).unwrap();
+
+        // The shipped file still holds the shipped preset.
+        let on_disk: Preset =
+            serde_json::from_str(&fs::read_to_string(&factory_path).unwrap()).unwrap();
+        assert_eq!(on_disk.name, "High Gain", "factory preset was clobbered");
+
+        // The new preset stepped aside onto the digest-suffixed stem.
+        let disambiguated = dir
+            .path()
+            .join(format!("High_Gain-{:016x}.json", stable_hash(b"High_Gain")));
+        assert!(disambiguated.exists(), "no separate file for `High_Gain`");
+
+        // Two presets, two files, nothing lost — proven through a fresh reload.
+        assert_eq!(json_files(dir.path()).len(), 2);
+        let reloaded = Manager::new(dir.path()).unwrap();
+        assert_eq!(reloaded.get_presets().len(), 2);
+        assert!(reloaded.get_preset_by_name("High Gain").is_some());
+        assert!(reloaded.get_preset_by_name("High_Gain").is_some());
+    }
+
+    /// `sanitize_filename` is injective only below the truncation boundary: a
+    /// digest-suffixed stem is itself a valid identity encoding. `path_for`'s
+    /// occupancy check, not the encoding, is what keeps the two names apart.
+    #[test]
+    fn a_long_name_and_its_digest_stem_namesake_get_separate_files() {
+        let long = "x".repeat(500);
+        let namesake = sanitize_filename(&long);
+        assert_eq!(
+            sanitize_filename(&namesake),
+            namesake,
+            "expected the stems to collide"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut manager = Manager::new(dir.path()).unwrap();
+        manager.save_preset(&preset_named(&long)).unwrap();
+        manager.save_preset(&preset_named(&namesake)).unwrap();
+
+        assert_eq!(json_files(dir.path()).len(), 2);
+        let reloaded = Manager::new(dir.path()).unwrap();
+        assert_eq!(reloaded.get_presets().len(), 2);
+        assert!(reloaded.get_preset_by_name(&long).is_some());
+        assert!(reloaded.get_preset_by_name(&namesake).is_some());
+    }
+
+    /// Deleting by name must never fall back to a name-derived path: the file it
+    /// computes may belong to a different preset entirely.
+    #[test]
+    fn deleting_a_name_that_lands_on_another_presets_file_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let other_path = dir.path().join("My_Preset.json");
+        fs::write(
+            &other_path,
+            serde_json::to_string(&preset_named("My Preset")).unwrap(),
+        )
+        .unwrap();
+
+        let mut manager = Manager::new(dir.path()).unwrap();
+        let err = manager.delete_preset("My_Preset").unwrap_err();
+
+        assert!(
+            err.to_string().contains("Preset file not found"),
+            "unexpected error: {err}"
+        );
+        assert!(other_path.exists(), "deleted another preset's file");
+        assert!(manager.get_preset_by_name("My Preset").is_some());
     }
 
     #[test]

--- a/rustortion-core/src/preset/manager.rs
+++ b/rustortion-core/src/preset/manager.rs
@@ -1,12 +1,21 @@
 use super::{InputFilterConfig, Preset, StageCategory};
 use anyhow::{Context, Result};
 use log::warn;
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 pub struct Manager {
     presets_dir: PathBuf,
     presets: Vec<Preset>,
+    /// Maps a loaded preset's `name` to the file it was read from.
+    ///
+    /// Presets are identified by the `name` field *inside* the JSON, never by
+    /// their filename, so the on-disk name is free to change between releases.
+    /// Remembering where each preset actually came from lets saves and deletes
+    /// target the existing file — including files written by older versions
+    /// under a different sanitising scheme — instead of orphaning them.
+    preset_paths: HashMap<String, PathBuf>,
 }
 
 impl Manager {
@@ -17,6 +26,7 @@ impl Manager {
         let mut manager = Self {
             presets_dir,
             presets: Vec::new(),
+            preset_paths: HashMap::new(),
         };
 
         manager.load_presets()?;
@@ -31,11 +41,13 @@ impl Manager {
         Self {
             presets_dir: PathBuf::new(),
             presets,
+            preset_paths: HashMap::new(),
         }
     }
 
     pub fn load_presets(&mut self) -> Result<()> {
         self.presets.clear();
+        self.preset_paths.clear();
 
         if !self.presets_dir.exists() {
             return Ok(());
@@ -47,7 +59,10 @@ impl Manager {
 
             if path.extension().and_then(|s| s.to_str()) == Some("json") {
                 match self.load_preset_file(&path) {
-                    Ok(preset) => self.presets.push(preset),
+                    Ok(preset) => {
+                        self.preset_paths.insert(preset.name.clone(), path);
+                        self.presets.push(preset);
+                    }
                     Err(e) => {
                         warn!("Failed to load preset {}: {e}", path.display());
                     }
@@ -83,8 +98,7 @@ impl Manager {
         if self.presets_dir.as_os_str().is_empty() {
             return Err(anyhow::anyhow!("Cannot save presets in read-only mode"));
         }
-        let filename = format!("{}.json", sanitize_filename(&preset.name));
-        let path = self.presets_dir.join(filename);
+        let path = self.path_for(&preset.name);
 
         let json = serde_json::to_string_pretty(preset).context("Failed to serialize preset")?;
 
@@ -100,8 +114,7 @@ impl Manager {
         if self.presets_dir.as_os_str().is_empty() {
             return Err(anyhow::anyhow!("Cannot delete presets in read-only mode"));
         }
-        let filename = format!("{}.json", sanitize_filename(preset_name));
-        let path = self.presets_dir.join(filename);
+        let path = self.path_for(preset_name);
 
         if path.exists() {
             fs::remove_file(&path).context("Failed to delete preset file")?;
@@ -125,6 +138,22 @@ impl Manager {
 
     pub fn get_preset_by_name(&self, name: &str) -> Option<&Preset> {
         self.presets.iter().find(|p| p.name == name)
+    }
+
+    /// Resolve the file a preset should be written to (or deleted from).
+    ///
+    /// If the preset is already on disk we reuse the exact path it was loaded
+    /// from, so presets saved by older versions keep their existing filenames
+    /// and never end up duplicated. Only presets that do not exist yet get a
+    /// freshly encoded filename.
+    fn path_for(&self, preset_name: &str) -> PathBuf {
+        self.preset_paths.get(preset_name).map_or_else(
+            || {
+                self.presets_dir
+                    .join(format!("{}.json", sanitize_filename(preset_name)))
+            },
+            Clone::clone,
+        )
     }
 }
 
@@ -219,18 +248,284 @@ fn enforce_stage_ordering(preset: &mut Preset) {
     preset.stages.append(&mut effect_stages);
 }
 
+/// Bytes that survive into a filename verbatim. Deliberately the same set the
+/// previous (lossy) scheme kept, so any preset name that was already safe keeps
+/// the exact filename it has today.
+const fn is_unreserved(byte: u8) -> bool {
+    matches!(byte, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_')
+}
+
+/// Longest filename stem we will produce, in bytes. Almost every filesystem
+/// caps a single path component at 255 bytes; this leaves room for `.json`
+/// plus a little slack.
+const MAX_STEM_BYTES: usize = 200;
+
+/// `'-'` plus 16 hex digits, appended to truncated stems.
+const HASH_SUFFIX_BYTES: usize = 17;
+
+const HEX_DIGITS: [u8; 16] = *b"0123456789ABCDEF";
+
+/// 64-bit FNV-1a.
+///
+/// Hand-rolled rather than using `DefaultHasher`, whose algorithm is explicitly
+/// not stable across Rust releases — these hashes end up in filenames, so they
+/// have to survive a toolchain upgrade.
+fn stable_hash(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Percent-encode `name` into at most `budget` bytes. Returns the encoded text
+/// and whether it had to stop early. Only whole units (one plain byte or one
+/// complete `%XX` triplet) are emitted, so the result is never a split escape.
+fn percent_encode(name: &str, budget: usize) -> (String, bool) {
+    let mut out = String::with_capacity(name.len());
+
+    for &byte in name.as_bytes() {
+        let width = if is_unreserved(byte) { 1 } else { 3 };
+        if out.len() + width > budget {
+            return (out, true);
+        }
+
+        if is_unreserved(byte) {
+            out.push(byte as char);
+        } else {
+            out.push('%');
+            out.push(HEX_DIGITS[(byte >> 4) as usize] as char);
+            out.push(HEX_DIGITS[(byte & 0x0f) as usize] as char);
+        }
+    }
+
+    (out, false)
+}
+
+/// Turn a preset name into a filename stem that is unique to that name.
+///
+/// Percent-encoding every byte outside `[A-Za-z0-9-_]` is injective, so two
+/// different preset names can never land on the same file. It is also stable
+/// and reversible, and — crucially for existing installs — it is the identity
+/// on names that only use the allowed characters, which is exactly the set of
+/// names the old scheme left untouched.
+///
+/// The old scheme mapped everything else to `_`, which collapsed *every*
+/// non-ASCII name (a whole locale's worth of preset names) onto a single file.
 fn sanitize_filename(name: &str) -> String {
-    name.chars()
-        .map(|c| match c {
-            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => c,
-            _ => '_',
-        })
-        .collect()
+    if name.is_empty() {
+        // The encoder never emits a bare `%` — every `%` it writes is followed
+        // by two hex digits — so this cannot collide with a real name.
+        return "%".to_owned();
+    }
+
+    let (encoded, truncated) = percent_encode(name, MAX_STEM_BYTES);
+    if !truncated {
+        return encoded;
+    }
+
+    // Pathologically long names get a readable prefix plus a digest of the full
+    // name, which keeps distinct names distinct without blowing the filesystem's
+    // per-component byte limit.
+    let (stem, _) = percent_encode(name, MAX_STEM_BYTES - HASH_SUFFIX_BYTES);
+    let hash = stable_hash(name.as_bytes());
+    format!("{stem}-{hash:016x}")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::amp::stages::level::LevelConfig;
+    use crate::preset::StageConfig;
+    use std::collections::HashSet;
+
+    fn preset_named(name: &str) -> Preset {
+        Preset::new(
+            name.to_owned(),
+            vec![StageConfig::Level(LevelConfig::default())],
+            Some("cab.wav".to_owned()),
+            0.25,
+            -2,
+            InputFilterConfig::default(),
+        )
+    }
+
+    /// Existing installs already have files on disk. Any name the old scheme
+    /// left alone must still map to the same filename, or every ASCII preset
+    /// would be orphaned on upgrade.
+    #[test]
+    fn sanitize_filename_leaves_already_safe_names_unchanged() {
+        for name in ["Rock", "lead-tone_2", "ABC123", "_", "-", "a"] {
+            assert_eq!(sanitize_filename(name), name, "name {name:?} was rewritten");
+        }
+    }
+
+    /// The bug: every ZH_CN name used to collapse to a run of underscores, so a
+    /// Chinese-locale user effectively had a single preset slot.
+    #[test]
+    fn sanitize_filename_distinguishes_zh_cn_names() {
+        let metal = sanitize_filename("重金属");
+        let clean = sanitize_filename("清音");
+
+        assert_eq!(metal, "%E9%87%8D%E9%87%91%E5%B1%9E");
+        assert_eq!(clean, "%E6%B8%85%E9%9F%B3");
+        assert_ne!(metal, clean);
+        // Nothing collapses to the old all-underscore stem.
+        assert!(!metal.contains('_'));
+        assert!(!clean.contains('_'));
+    }
+
+    #[test]
+    fn sanitize_filename_distinguishes_punctuation_only_differences() {
+        let names = [
+            "My Preset",
+            "My-Preset",
+            "My_Preset",
+            "My.Preset",
+            "My/Preset",
+            "My:Preset",
+            "MyPreset",
+            // `%` must itself be escaped or the encoding would not be injective:
+            // "My%20Preset" and "My Preset" would otherwise share a file.
+            "My%20Preset",
+        ];
+
+        let stems: HashSet<String> = names.iter().map(|n| sanitize_filename(n)).collect();
+        assert_eq!(stems.len(), names.len(), "punctuation variants collided");
+
+        assert_eq!(sanitize_filename("My Preset"), "My%20Preset");
+        assert_eq!(sanitize_filename("My%20Preset"), "My%2520Preset");
+        // A path separator can never survive into the filename.
+        assert!(!sanitize_filename("My/Preset").contains('/'));
+    }
+
+    #[test]
+    fn sanitize_filename_bounds_length_without_colliding() {
+        let long_ascii = "x".repeat(500);
+        let long_zh = "重".repeat(500);
+
+        for stem in [
+            sanitize_filename(&long_ascii),
+            sanitize_filename(&long_zh),
+            sanitize_filename(&format!("{long_ascii}y")),
+        ] {
+            assert!(
+                stem.len() <= MAX_STEM_BYTES,
+                "stem too long: {}",
+                stem.len()
+            );
+        }
+
+        // Names sharing a long prefix still get distinct filenames.
+        assert_ne!(
+            sanitize_filename(&format!("{long_ascii}a")),
+            sanitize_filename(&format!("{long_ascii}b"))
+        );
+        assert_ne!(
+            sanitize_filename(&format!("{long_zh}重")),
+            sanitize_filename(&format!("{long_zh}金"))
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_is_deterministic() {
+        assert_eq!(sanitize_filename("重金属"), sanitize_filename("重金属"));
+        let long = "重".repeat(500);
+        assert_eq!(sanitize_filename(&long), sanitize_filename(&long));
+    }
+
+    #[test]
+    fn save_preset_round_trips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manager = Manager::new(dir.path()).unwrap();
+
+        manager.save_preset(&preset_named("重金属 v2")).unwrap();
+
+        // Re-read from scratch to prove the file, not the in-memory copy.
+        let reloaded = Manager::new(dir.path()).unwrap();
+        let preset = reloaded
+            .get_preset_by_name("重金属 v2")
+            .expect("preset missing after reload");
+
+        assert_eq!(preset.name, "重金属 v2");
+        assert_eq!(preset.stages.len(), 1);
+        assert_eq!(preset.ir_name.as_deref(), Some("cab.wav"));
+        assert!((preset.ir_gain - 0.25).abs() < f32::EPSILON);
+        assert_eq!(preset.pitch_shift_semitones, -2);
+    }
+
+    #[test]
+    fn distinct_zh_cn_presets_do_not_overwrite_each_other() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manager = Manager::new(dir.path()).unwrap();
+
+        for name in ["重金属", "清音", "布鲁斯"] {
+            manager.save_preset(&preset_named(name)).unwrap();
+        }
+
+        assert_eq!(manager.get_presets().len(), 3);
+        let reloaded = Manager::new(dir.path()).unwrap();
+        assert_eq!(reloaded.get_presets().len(), 3);
+        for name in ["重金属", "清音", "布鲁斯"] {
+            assert!(reloaded.get_preset_by_name(name).is_some(), "lost {name}");
+        }
+    }
+
+    /// Backward compatibility: a preset written by an older version under the
+    /// lossy scheme must be updated in place, not duplicated under a new name.
+    #[test]
+    fn saving_over_a_legacy_filename_reuses_that_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let legacy_path = dir.path().join("My_Preset.json");
+        let legacy = Preset::new(
+            "My Preset".to_owned(),
+            Vec::new(),
+            None,
+            0.1,
+            0,
+            InputFilterConfig::default(),
+        );
+        fs::write(&legacy_path, serde_json::to_string(&legacy).unwrap()).unwrap();
+
+        let mut manager = Manager::new(dir.path()).unwrap();
+        assert_eq!(manager.get_presets().len(), 1);
+
+        manager.save_preset(&preset_named("My Preset")).unwrap();
+
+        assert!(legacy_path.exists(), "legacy file was orphaned");
+        assert!(!dir.path().join("My%20Preset.json").exists());
+        assert_eq!(manager.get_presets().len(), 1, "preset was duplicated");
+        assert_eq!(
+            manager
+                .get_preset_by_name("My Preset")
+                .unwrap()
+                .stages
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn deleting_a_legacy_filename_works() {
+        let dir = tempfile::tempdir().unwrap();
+        let legacy_path = dir.path().join("____.json");
+        let legacy = Preset::new(
+            "重金属".to_owned(),
+            Vec::new(),
+            None,
+            0.1,
+            0,
+            InputFilterConfig::default(),
+        );
+        fs::write(&legacy_path, serde_json::to_string(&legacy).unwrap()).unwrap();
+
+        let mut manager = Manager::new(dir.path()).unwrap();
+        manager.delete_preset("重金属").unwrap();
+
+        assert!(!legacy_path.exists());
+        assert!(manager.get_presets().is_empty());
+    }
 
     #[test]
     fn test_migrate_preset_extracts_filters() {

--- a/rustortion-core/src/preset/stage_config.rs
+++ b/rustortion-core/src/preset/stage_config.rs
@@ -212,6 +212,88 @@ impl StageConfig {
 mod tests {
     use super::*;
 
+    /// The externally-tagged JSON key each `StageConfig` variant serializes to.
+    ///
+    /// These strings are a **file format**: they appear in every preset in
+    /// `~/.config/rustortion/presets/` and in every DAW project that persisted a
+    /// plugin chain. Renaming a variant (or adding `#[serde(rename)]`) would
+    /// silently make every existing preset unreadable, so they are pinned here
+    /// as literals rather than derived from the enum.
+    const WIRE_NAMES: &[(StageType, &str)] = &[
+        (StageType::Preamp, "Preamp"),
+        (StageType::Compressor, "Compressor"),
+        (StageType::ToneStack, "ToneStack"),
+        (StageType::PowerAmp, "PowerAmp"),
+        (StageType::Level, "Level"),
+        (StageType::NoiseGate, "NoiseGate"),
+        (StageType::MultibandSaturator, "MultibandSaturator"),
+        (StageType::Nam, "Nam"),
+        (StageType::Delay, "Delay"),
+        (StageType::Reverb, "Reverb"),
+        (StageType::Eq, "Eq"),
+        (StageType::Tremolo, "Tremolo"),
+    ];
+
+    /// Fails if a stage is registered in `StageType::ALL` but not pinned above,
+    /// so adding a 13th stage forces its wire name into the guard below.
+    #[test]
+    fn every_registered_stage_has_a_pinned_wire_name() {
+        assert_eq!(WIRE_NAMES.len(), StageType::ALL.len());
+        for stage_type in StageType::ALL {
+            assert!(
+                WIRE_NAMES.iter().any(|(t, _)| t == stage_type),
+                "{stage_type} is registered but has no pinned wire name"
+            );
+        }
+    }
+
+    #[test]
+    fn every_stage_config_variant_round_trips_under_a_stable_name() {
+        for (stage_type, wire_name) in WIRE_NAMES {
+            let config = StageConfig::from(*stage_type);
+
+            let value = serde_json::to_value(&config)
+                .unwrap_or_else(|e| panic!("serialize {stage_type}: {e}"));
+            let obj = value
+                .as_object()
+                .unwrap_or_else(|| panic!("{stage_type} did not serialize as a tagged object"));
+            assert_eq!(obj.len(), 1, "{stage_type} serialized to more than one key");
+            assert_eq!(
+                obj.keys().next().unwrap(),
+                wire_name,
+                "{stage_type} changed its on-disk key — this breaks existing presets"
+            );
+
+            let restored: StageConfig = serde_json::from_value(value.clone())
+                .unwrap_or_else(|e| panic!("deserialize {stage_type}: {e}"));
+            assert_eq!(restored.stage_type(), *stage_type);
+            assert_eq!(
+                serde_json::to_value(&restored).unwrap(),
+                value,
+                "{stage_type} lost or renamed a field across the round trip"
+            );
+        }
+    }
+
+    /// The default configs are mostly zeroes and falses, which would hide a
+    /// field rename that happens to share a default. Flip a field that every
+    /// variant has and prove it survives.
+    #[test]
+    fn every_stage_config_variant_round_trips_a_non_default_field() {
+        for (stage_type, _) in WIRE_NAMES {
+            let mut config = StageConfig::from(*stage_type);
+            assert!(!config.bypassed(), "{stage_type} defaults to bypassed");
+            config.set_bypassed(true);
+
+            let json = serde_json::to_string(&config).unwrap();
+            let restored: StageConfig = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("deserialize {stage_type}: {e}"));
+
+            assert_eq!(restored.stage_type(), *stage_type);
+            assert!(restored.bypassed(), "{stage_type} lost its bypass flag");
+        }
+    }
+
     /// The plugin persists its chain as `Vec<StageConfig>` JSON in `chain_state`
     /// (nih-plug `#[persist]`), and a NAM stage stores its model BY NAME. This is
     /// the exact path that recalls a selected model when a DAW project reopens, so

--- a/rustortion-standalone/src/gui/app.rs
+++ b/rustortion-standalone/src/gui/app.rs
@@ -227,15 +227,19 @@ impl AmplifierApp {
 
         let is_preset_select_or_save = matches!(
             message,
-            Message::Preset(PresetMessage::Select(_) | PresetMessage::Save(_))
+            Message::Preset(
+                PresetMessage::Select(_) | PresetMessage::Save(_) | PresetMessage::SaveConfirmed(_)
+            )
         );
         let is_preset_delete = matches!(message, Message::Preset(PresetMessage::Delete(_)));
 
         // Clone preset name for persistence if needed
         let preset_name_for_persist = match &message {
-            Message::Preset(PresetMessage::Select(name) | PresetMessage::Save(name)) => {
-                Some(name.clone())
-            }
+            Message::Preset(
+                PresetMessage::Select(name)
+                | PresetMessage::Save(name)
+                | PresetMessage::SaveConfirmed(name),
+            ) => Some(name.clone()),
             _ => None,
         };
         let deleted_preset_name = match &message {

--- a/rustortion-standalone/src/gui/app.rs
+++ b/rustortion-standalone/src/gui/app.rs
@@ -225,12 +225,6 @@ impl AmplifierApp {
             Message::Hotkey(HotkeyMessage::ConfirmMapping | HotkeyMessage::RemoveMapping(_))
         );
 
-        let is_preset_select_or_save = matches!(
-            message,
-            Message::Preset(
-                PresetMessage::Select(_) | PresetMessage::Save(_) | PresetMessage::SaveConfirmed(_)
-            )
-        );
         let is_preset_delete = matches!(message, Message::Preset(PresetMessage::Delete(_)));
 
         // Clone preset name for persistence if needed
@@ -287,7 +281,15 @@ impl AmplifierApp {
             self.save_settings();
         }
 
-        if is_preset_select_or_save && let Some(name) = preset_name_for_persist {
+        // Persist the selection only when the message actually moved it. `Save`
+        // may do nothing but raise the overwrite prompt, and writing the new
+        // name to settings.json before the user answers means cancelling still
+        // leaves the next launch opening a preset that was never saved. The
+        // handler advances its own selection only when the work really
+        // happened, so mirror that rather than guessing from the message.
+        if let Some(name) = preset_name_for_persist
+            && self.shared.preset_handler.selected_preset_name() == Some(name.as_str())
+        {
             self.settings.selected_preset = Some(name);
             self.save_settings();
         }
@@ -392,6 +394,10 @@ impl AmplifierApp {
             || self.tuner_handler.is_visible()
             || self.midi_handler.is_visible()
             || self.shared.hotkey_handler.is_visible()
+            // A preset-switch hotkey fired between Save and Yes would swap the
+            // whole chain out from under the pending confirmation, which then
+            // writes the newly loaded chain over the confirmed name.
+            || self.shared.preset_handler.is_overwrite_confirmation_visible()
     }
 
     fn persist_collapse_state(&mut self) {

--- a/rustortion-ui/src/components/preset_bar.rs
+++ b/rustortion-ui/src/components/preset_bar.rs
@@ -42,10 +42,9 @@ impl PresetBar {
                 self.set_new_preset_name(name);
             }
             PresetGuiMessage::ConfirmOverwrite => {
+                let name = std::mem::take(&mut self.overwrite_target);
                 self.hide_overwrite_confirmation();
-                return Task::done(Message::Preset(PresetMessage::Save(
-                    self.preset_name_input.clone(),
-                )));
+                return Task::done(Message::Preset(PresetMessage::SaveConfirmed(name)));
             }
             PresetGuiMessage::CancelOverwrite => {
                 self.hide_overwrite_confirmation();

--- a/rustortion-ui/src/components/preset_bar.rs
+++ b/rustortion-ui/src/components/preset_bar.rs
@@ -72,6 +72,12 @@ impl PresetBar {
         self.overwrite_target = preset_name;
     }
 
+    /// Is the overwrite prompt currently up? Hosts block key events while a
+    /// dialog is open, and this one is modal in every way that matters.
+    pub const fn is_overwrite_confirmation_visible(&self) -> bool {
+        self.show_overwrite_confirmation
+    }
+
     pub fn hide_overwrite_confirmation(&mut self) {
         self.show_overwrite_confirmation = false;
         self.overwrite_target.clear();

--- a/rustortion-ui/src/handlers/preset.rs
+++ b/rustortion-ui/src/handlers/preset.rs
@@ -70,6 +70,26 @@ impl PresetHandler {
             PresetMessage::Save(name) => {
                 debug!("Saving preset... {name}");
                 if !name.trim().is_empty() {
+                    // Saves are destructive and not undoable, so ask before
+                    // clobbering someone else's preset. `Update` is exempt:
+                    // overwriting the selected preset is the whole point.
+                    if self.preset_manager.preset_exists(&name) {
+                        self.preset_bar.show_overwrite_confirmation(name);
+                    } else {
+                        self.save_preset_named(
+                            &name,
+                            stages,
+                            ir_name,
+                            ir_gain,
+                            pitch_shift_semitones,
+                            input_filters,
+                        );
+                    }
+                }
+            }
+            PresetMessage::SaveConfirmed(name) => {
+                debug!("Overwriting preset... {name}");
+                if !name.trim().is_empty() {
                     self.save_preset_named(
                         &name,
                         stages,

--- a/rustortion-ui/src/handlers/preset.rs
+++ b/rustortion-ui/src/handlers/preset.rs
@@ -144,6 +144,20 @@ impl PresetHandler {
         &self.available_presets
     }
 
+    /// The preset the handler currently considers selected.
+    ///
+    /// Only moves when a select or save actually succeeded, so callers can use
+    /// it to decide whether a `Save` did any work or merely raised the
+    /// overwrite prompt.
+    pub fn selected_preset_name(&self) -> Option<&str> {
+        self.selected_preset.as_deref()
+    }
+
+    /// Whether the overwrite confirmation prompt is on screen.
+    pub const fn is_overwrite_confirmation_visible(&self) -> bool {
+        self.preset_bar.is_overwrite_confirmation_visible()
+    }
+
     pub fn selected_preset_index(&self) -> Option<usize> {
         let name = self.selected_preset.as_ref()?;
         self.available_presets.iter().position(|n| n == name)

--- a/rustortion-ui/src/messages/preset.rs
+++ b/rustortion-ui/src/messages/preset.rs
@@ -1,7 +1,11 @@
 #[derive(Debug, Clone)]
 pub enum PresetMessage {
     Select(String),
+    /// Save under a new name. Prompts first if a preset by that name exists.
     Save(String),
+    /// Save under a name that has already passed the overwrite confirmation.
+    /// Kept separate from `Save` so confirming cannot re-trigger the prompt.
+    SaveConfirmed(String),
     Update,
     Delete(String),
     Gui(PresetGuiMessage),


### PR DESCRIPTION
Closes the REV-7 half of the v0.3.0 gate, with TEST-7.

## The bug

`sanitize_filename` mapped every byte outside `[A-Za-z0-9-_]` to `_`, with no collision check, and both `save_preset` and `delete_preset` went through it. Every ZH_CN preset name therefore collapsed onto the same file: a Chinese-locale user effectively had **one preset slot**, and each save destroyed the previous one. ZH_CN is a shipped locale.

The display name was never affected — presets are identified by the `name` field inside the JSON — so this looked like presets silently vanishing rather than anything visibly wrong.

Separately, the overwrite-confirmation dialog was fully built in `preset_bar.rs` but `show_overwrite_confirmation()` had **zero call sites**, so saves always overwrote silently.

## The fix

Percent-encode the disallowed bytes instead. The encoding is injective (`%` is itself escaped as `%25`), stable, and the identity on names the old scheme already left alone.

**Backward compatibility.** Percent-encoding alone would orphan existing files: a legacy `My_Preset.json` (name `"My Preset"`) would get saved to a *new* `My%20Preset.json`, leaving the old file behind — the preset would then appear twice and delete would miss. So `Manager` now records the path each preset was loaded from and reuses it on save/delete. Files written by older versions are updated in place; only presets that don't exist yet get a freshly encoded name.

Pathologically long names are truncated on an escape-unit boundary (never mid-`%XX`) and suffixed with an FNV-1a digest — hand-rolled because `DefaultHasher`'s algorithm is explicitly unstable across Rust releases and these values land in filenames.

The overwrite dialog is now wired up. `PresetMessage::SaveConfirmed` is kept separate from `Save` so confirming can't re-trigger the prompt. `Update` stays exempt — overwriting the selected preset is its purpose. No new UI strings, so no i18n work: `overwrite_preset` / `yes` / `no` already exist in EN and ZH_CN.

## Known residual

Names differing only in ASCII case still share a file on case-insensitive filesystems. Encoding case would have changed the filename of every existing preset — a far worse trade. Preset *writing* only happens in the standalone, whose release targets are both case-sensitive Linux.

## Out of scope

Deliberately deferred to v0.4.0, per the gate scoping: the non-atomic `fs::write` (crash mid-write leaves truncated JSON) and the missing UI error surface for save/delete failures. Both are narrower windows than the collision.

## Tests

+12. `sanitize_filename` injectivity across ZH_CN names, punctuation-only differences, `%`, and length bounds, plus identity on already-safe names. A save -> load round trip and legacy-filename save/delete through a temp dir. And a serde guard pinning the on-disk key of **all 12** `StageConfig` variants — previously exactly one had round-trip coverage, so a serde rename would have silently broken every user's presets.

Verified on the integration branch with all four gate items: 302 passed, 0 failed, lint clean.