### PR TITLE
fix(plugin): flush all DSP state on host transport reset (PLUG-2)

### DIFF
--- a/rustortion-core/src/amp/chain.rs
+++ b/rustortion-core/src/amp/chain.rs
@@ -66,6 +66,19 @@ impl AmplifierChain {
         }
     }
 
+    /// Clear the accumulated state of every stage (see [`Stage::reset`]).
+    ///
+    /// Bypassed stages are reset too: their state is frozen, not gone, and
+    /// un-bypassing one that still held a pre-seek delay line would spill that
+    /// audio into the present.
+    ///
+    /// RT-safe — every `Stage::reset` zeroes in place.
+    pub fn reset(&mut self) {
+        for stage in &mut self.stages {
+            stage.inner.reset();
+        }
+    }
+
     /// Forward a parameter change to a live stage.
     pub fn set_parameter(
         &mut self,
@@ -292,6 +305,61 @@ mod tests {
             (out - 1.0).abs() < 1e-6,
             "remaining bypassed stage should pass through"
         );
+    }
+
+    /// PLUG-2: the chain must forward `reset` to every stage it holds.
+    #[test]
+    fn reset_clears_every_stage() {
+        use crate::amp::stages::delay::DelayStage;
+
+        let mut chain = AmplifierChain::new();
+        chain.add_stage(Box::new(DelayStage::new(20.0, 0.8, 1.0, 48_000.0)));
+        chain.add_stage(Box::new(DelayStage::new(30.0, 0.8, 1.0, 48_000.0)));
+
+        // Load both delay lines up.
+        for _ in 0..48_000 {
+            chain.process(0.0);
+        }
+        chain.process(1.0);
+        for _ in 0..500 {
+            chain.process(0.0);
+        }
+
+        chain.reset();
+
+        for i in 0..48_000 {
+            let out = chain.process(0.0);
+            assert!(out.abs() < 1e-9, "stage state survived reset at {i}: {out}");
+        }
+    }
+
+    /// A bypassed stage's state is frozen, not gone. Un-bypassing one that
+    /// still held pre-seek audio would spill it into the present, so `reset`
+    /// covers bypassed stages too.
+    #[test]
+    fn reset_also_clears_bypassed_stages() {
+        use crate::amp::stages::delay::DelayStage;
+
+        let mut chain = AmplifierChain::new();
+        chain.add_stage(Box::new(DelayStage::new(20.0, 0.8, 1.0, 48_000.0)));
+
+        for _ in 0..48_000 {
+            chain.process(0.0);
+        }
+        chain.process(1.0);
+
+        // Bypass it, reset the chain, then bring it back.
+        chain.set_bypassed(0, true);
+        chain.reset();
+        chain.set_bypassed(0, false);
+
+        for i in 0..48_000 {
+            let out = chain.process(0.0);
+            assert!(
+                out.abs() < 1e-9,
+                "bypassed stage kept its state through reset at {i}: {out}"
+            );
+        }
     }
 
     #[test]

--- a/rustortion-core/src/amp/stages/common.rs
+++ b/rustortion-core/src/amp/stages/common.rs
@@ -37,6 +37,12 @@ impl DcBlocker {
         }
     }
 
+    /// Zero the filter memory, keeping the cutoff coefficient.
+    pub const fn reset(&mut self) {
+        self.x_prev = 0.0;
+        self.y_prev = 0.0;
+    }
+
     #[inline]
     pub fn process(&mut self, input: f32) -> f32 {
         let output = self.coeff.mul_add(self.y_prev, input - self.x_prev);
@@ -60,6 +66,11 @@ impl OnePoleLP {
     pub fn new(cutoff_hz: f32, sample_rate: f32) -> Self {
         let coeff = 1.0 - (-2.0 * PI * cutoff_hz / sample_rate).exp();
         Self { y_prev: 0.0, coeff }
+    }
+
+    /// Zero the filter memory, keeping the cutoff coefficient.
+    pub const fn reset(&mut self) {
+        self.y_prev = 0.0;
     }
 
     #[inline]

--- a/rustortion-core/src/amp/stages/compressor.rs
+++ b/rustortion-core/src/amp/stages/compressor.rs
@@ -64,6 +64,12 @@ impl Stage for CompressorStage {
         input * gain_reduction * self.makeup
     }
 
+    /// Drops the level envelope back to zero, so the first block after a seek
+    /// is not gain-reduced by whatever was loud before it.
+    fn reset(&mut self) {
+        self.envelope.reset();
+    }
+
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
         match name {
             "threshold" => {

--- a/rustortion-core/src/amp/stages/delay.rs
+++ b/rustortion-core/src/amp/stages/delay.rs
@@ -85,6 +85,16 @@ impl Stage for DelayStage {
         (1.0 - self.mix).mul_add(input, self.mix * delayed)
     }
 
+    /// Empties the echo line so no repeat survives a seek, and snaps the delay
+    /// time smoother straight to its target — after a jump there is no previous
+    /// delay time worth gliding from, and a glide would pitch-bend the first
+    /// repeat.
+    fn reset(&mut self) {
+        self.buffer.fill(0.0);
+        self.write_pos = 0;
+        self.delay_samples_smoothed = self.delay_samples_target;
+    }
+
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
         match name {
             "delay_time" => {
@@ -341,6 +351,83 @@ mod tests {
         assert!(
             max_out > 0.9,
             "Impulse should survive at high sample rate, got max {max_out}"
+        );
+    }
+
+    /// PLUG-2: the whole point of `reset` — a repeat queued before a transport
+    /// jump must not play over the audio after it.
+    #[test]
+    fn reset_clears_the_echo_line() {
+        let delay_ms = 50.0;
+        let delay_samples = (delay_ms * 0.001 * SAMPLE_RATE) as usize;
+        let mut delay = DelayStage::new(delay_ms, 0.8, 1.0, SAMPLE_RATE);
+
+        // Warm the smoother, then load the line with an impulse.
+        for _ in 0..SAMPLE_RATE as usize {
+            delay.process(0.0);
+        }
+        let _ = delay.process(1.0);
+        for _ in 0..delay_samples / 2 {
+            delay.process(0.0);
+        }
+
+        delay.reset();
+
+        // Every repeat that was in flight is gone: silence in, silence out for
+        // longer than the tail would have lasted.
+        for i in 0..delay_samples * 4 {
+            let out = delay.process(0.0);
+            assert!(out.abs() < 1e-9, "echo survived reset at sample {i}: {out}");
+        }
+    }
+
+    /// Reset clears state but must not disturb the settings.
+    #[test]
+    fn reset_preserves_parameters() {
+        let mut delay = DelayStage::new(300.0, 0.4, 0.6, SAMPLE_RATE);
+        delay.process(1.0);
+        delay.reset();
+
+        assert!((delay.get_parameter("delay_time").unwrap() - 300.0).abs() < 1e-6);
+        assert!((delay.get_parameter("feedback").unwrap() - 0.4).abs() < 1e-6);
+        assert!((delay.get_parameter("mix").unwrap() - 0.6).abs() < 1e-6);
+    }
+
+    /// Reset snaps the time smoother to its target, so the first repeat after a
+    /// seek lands at the configured delay instead of gliding in from wherever
+    /// the smoother happened to be.
+    #[test]
+    fn reset_snaps_the_time_smoother() {
+        let delay_ms = 100.0;
+        let delay_samples = (delay_ms * 0.001 * SAMPLE_RATE) as usize;
+        let mut delay = DelayStage::new(500.0, 0.0, 1.0, SAMPLE_RATE);
+
+        // Converge on 500 ms, then jump the target to 100 ms *without* letting
+        // the smoother catch up, and reset.
+        for _ in 0..SAMPLE_RATE as usize {
+            delay.process(0.0);
+        }
+        delay.set_parameter("delay_time", delay_ms).unwrap();
+        delay.reset();
+
+        // The impulse must come back at the new time, not somewhere between.
+        let _ = delay.process(1.0);
+        let mut peak_at = 0;
+        let mut peak = 0.0_f32;
+        for i in 1..=delay_samples * 2 {
+            let out = delay.process(0.0).abs();
+            if out > peak {
+                peak = out;
+                peak_at = i;
+            }
+        }
+        assert!(
+            peak > 0.9,
+            "impulse should return at full level, got {peak}"
+        );
+        assert!(
+            peak_at.abs_diff(delay_samples) <= 2,
+            "repeat landed at {peak_at}, expected ~{delay_samples} — the smoother did not snap"
         );
     }
 

--- a/rustortion-core/src/amp/stages/eq.rs
+++ b/rustortion-core/src/amp/stages/eq.rs
@@ -51,6 +51,14 @@ impl Biquad {
         }
     }
 
+    /// Zero the Direct Form 1 delay registers, keeping the coefficients.
+    const fn reset(&mut self) {
+        self.x1 = 0.0;
+        self.x2 = 0.0;
+        self.y1 = 0.0;
+        self.y2 = 0.0;
+    }
+
     /// Set coefficients for a peaking EQ band using Audio EQ Cookbook formulas.
     ///
     /// Uses the BW-in-octaves alpha formula so that every band maintains
@@ -179,6 +187,14 @@ impl Stage for EqStage {
         out
     }
 
+    /// Clears the delay registers of all 16 cascaded biquads. Band gains (the
+    /// coefficients) are parameters, not state, and are left alone.
+    fn reset(&mut self) {
+        for biquad in &mut self.biquads {
+            biquad.reset();
+        }
+    }
+
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
         let idx =
             Self::parse_band_index(name).ok_or("Unknown parameter (expected band_0..=band_15)")?;
@@ -216,6 +232,42 @@ mod tests {
 
     fn flat_gains() -> [f32; NUM_BANDS] {
         [0.0; NUM_BANDS]
+    }
+
+    /// PLUG-2: 16 cascaded Direct Form 1 biquads hold 4 registers each. Reset
+    /// clears all 64 while leaving the band gains — which are coefficients, not
+    /// state — untouched.
+    #[test]
+    fn reset_clears_biquad_state() {
+        let mut gains = flat_gains();
+        gains[2] = 9.0;
+        gains[8] = -7.0;
+        gains[14] = 5.0;
+
+        let mut used = EqStage::new(gains, SAMPLE_RATE);
+        for i in 0..4096 {
+            used.process((i as f32 * 0.07).sin());
+        }
+        used.reset();
+
+        let mut fresh = EqStage::new(gains, SAMPLE_RATE);
+        for i in 0..2048 {
+            let input = (i as f32 * 0.13).sin();
+            let a = used.process(input);
+            let b = fresh.process(input);
+            assert!(
+                (a - b).abs() < 1e-6,
+                "sample {i}: reset EQ gave {a}, fresh EQ {b}"
+            );
+        }
+
+        for (i, &gain) in gains.iter().enumerate() {
+            let name = EqStage::band_param_name(i);
+            assert!(
+                (used.get_parameter(&name).unwrap() - gain).abs() < 1e-6,
+                "reset lost the gain of band {i}"
+            );
+        }
     }
 
     #[test]

--- a/rustortion-core/src/amp/stages/filter.rs
+++ b/rustortion-core/src/amp/stages/filter.rs
@@ -81,6 +81,12 @@ impl Stage for FilterStage {
         }
     }
 
+    /// Clears the one-sample input/output memory of the first-order section.
+    fn reset(&mut self) {
+        self.prev_input = 0.0;
+        self.prev_output = 0.0;
+    }
+
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
         match name {
             "cutoff" => {
@@ -157,6 +163,33 @@ mod tests {
             hf_avg_abs > 0.5,
             "High-frequency attenuated too much: avg_abs={hf_avg_abs}"
         );
+    }
+
+    /// PLUG-2: the engine runs two of these as input filters, so their one-pole
+    /// memory has to clear on a seek like everything else.
+    #[test]
+    fn reset_clears_filter_memory() {
+        for filter_type in [FilterType::Highpass, FilterType::Lowpass] {
+            let mut used = FilterStage::new(filter_type, 1_000.0, 48_000.0);
+            for _ in 0..1000 {
+                used.process(1.0);
+            }
+            used.reset();
+
+            let mut fresh = FilterStage::new(filter_type, 1_000.0, 48_000.0);
+            for i in 0..256 {
+                let input = (i as f32 * 0.1).sin();
+                let a = used.process(input);
+                let b = fresh.process(input);
+                assert!(
+                    (a - b).abs() < 1e-9,
+                    "{filter_type:?} sample {i}: reset gave {a}, fresh {b}"
+                );
+            }
+
+            // Cutoff is a parameter, not state.
+            assert!((used.get_parameter("cutoff").unwrap() - 1_000.0).abs() < 1e-6);
+        }
     }
 
     #[test]

--- a/rustortion-core/src/amp/stages/level.rs
+++ b/rustortion-core/src/amp/stages/level.rs
@@ -17,6 +17,9 @@ impl Stage for LevelStage {
         input * self.gain
     }
 
+    /// Memoryless — a pure gain multiply carries nothing across a seek.
+    fn reset(&mut self) {}
+
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
         match name {
             "gain" => {

--- a/rustortion-core/src/amp/stages/mod.rs
+++ b/rustortion-core/src/amp/stages/mod.rs
@@ -26,6 +26,27 @@ pub trait Stage: Send + Sync + 'static {
         }
     }
 
+    /// Discard every sample of accumulated state, returning the stage to the
+    /// condition it was in immediately after construction — delay lines and
+    /// filter memory zeroed, envelopes and LFO phase back at their initial
+    /// values — while leaving all *parameters* exactly as they are.
+    ///
+    /// Hosts call this on transport locate/seek (via nih-plug's
+    /// `Plugin::reset`), so without it a reverb tail or delay repeat from bar 32
+    /// keeps ringing over bar 1.
+    ///
+    /// # Real-time contract
+    ///
+    /// This runs **on the audio thread**. Implementations must zero their
+    /// buffers in place (`fill(0.0)`, resetting indices) and must never
+    /// allocate, free, lock, or perform I/O. `rustortion-core/tests/no_alloc.rs`
+    /// enforces this.
+    ///
+    /// Required rather than defaulted on purpose: adding a stage should force
+    /// the author to decide what its state is, and the compiler lists every
+    /// impl that has not.
+    fn reset(&mut self);
+
     // Set a parameter value by name
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str>;
 

--- a/rustortion-core/src/amp/stages/mod.rs
+++ b/rustortion-core/src/amp/stages/mod.rs
@@ -42,6 +42,22 @@ pub trait Stage: Send + Sync + 'static {
     /// allocate, free, lock, or perform I/O. `rustortion-core/tests/no_alloc.rs`
     /// enforces this.
     ///
+    /// # This is a discontinuity, by design
+    ///
+    /// Returning to construction state means the output *steps*. That is
+    /// correct at a locate, where the input is discontinuous anyway, but
+    /// nih-plug documents `Plugin::reset` as callable "at any other time from
+    /// the audio thread" — landing on continuous audio, it is audible. Measured
+    /// mid-signal: a dry preamp → power amp → tone stack chain steps 0.89 full
+    /// scale and settles over ~59 ms, as the DC blockers restart from zero.
+    /// Worst relative offender is the compressor, whose envelope drops to 0, so
+    /// the first ~20 ms after a locate is **uncompressed at full makeup gain**
+    /// (peak error 264% of the signal's own peak) — an overshoot into whatever
+    /// follows it.
+    ///
+    /// Softening this (output ramp, DC-blocker priming) is deliberately not
+    /// done here; it is a DSP design decision, not part of the flush contract.
+    ///
     /// Required rather than defaulted on purpose: adding a stage should force
     /// the author to decide what its state is, and the compiler lists every
     /// impl that has not.

--- a/rustortion-core/src/amp/stages/multiband_saturator.rs
+++ b/rustortion-core/src/amp/stages/multiband_saturator.rs
@@ -49,6 +49,18 @@ impl LR4Filter {
         filter
     }
 
+    /// Zero both cascaded biquads' delay registers, keeping the cutoff.
+    const fn reset(&mut self) {
+        self.x1_1 = 0.0;
+        self.x2_1 = 0.0;
+        self.y1_1 = 0.0;
+        self.y2_1 = 0.0;
+        self.x1_2 = 0.0;
+        self.x2_2 = 0.0;
+        self.y1_2 = 0.0;
+        self.y2_2 = 0.0;
+    }
+
     fn set_cutoff(&mut self, cutoff_hz: f32, sample_rate: f32) {
         // Butterworth Q for LR4 cascade
         let q = std::f32::consts::FRAC_1_SQRT_2;
@@ -254,6 +266,30 @@ impl Stage for MultibandSaturatorStage {
 
         // Mix bands with level controls and sum
         low_clean * self.low_level + mid_clean * self.mid_level + high_clean * self.high_level
+    }
+
+    /// Clears every piece of per-band memory: the six LR4 crossover /
+    /// phase-compensation filters (8 registers each), the three envelope
+    /// followers, and the three DC blockers.
+    fn reset(&mut self) {
+        for filter in [
+            &mut self.low_lp,
+            &mut self.mid_hp_low,
+            &mut self.mid_lp_high,
+            &mut self.high_hp,
+            &mut self.low_allpass_lp,
+            &mut self.low_allpass_hp,
+        ] {
+            filter.reset();
+        }
+
+        self.low_env.reset();
+        self.mid_env.reset();
+        self.high_env.reset();
+
+        self.low_dc.reset();
+        self.mid_dc.reset();
+        self.high_dc.reset();
     }
 
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {

--- a/rustortion-core/src/amp/stages/nam.rs
+++ b/rustortion-core/src/amp/stages/nam.rs
@@ -107,6 +107,20 @@ impl Stage for NamStage {
         }
     }
 
+    /// Returns the neural model to its initial conditions —
+    /// [`nam_rs::Model::reset`] clears the WaveNet ring buffers / LSTM
+    /// recurrent state (and every submodel of a slimmable model), allocating
+    /// nothing. A passthrough or rate-mismatch bypass has no state at all.
+    ///
+    /// The `dry` scratch buffer is deliberately left alone: every sample of it
+    /// that `process_block` reads is written earlier in the same call, and
+    /// keeping the allocation is the whole point of holding it.
+    fn reset(&mut self) {
+        if let Some(model) = self.model.as_mut() {
+            model.reset();
+        }
+    }
+
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
         match name {
             "input_gain_db" => {

--- a/rustortion-core/src/amp/stages/noise_gate.rs
+++ b/rustortion-core/src/amp/stages/noise_gate.rs
@@ -116,6 +116,15 @@ impl Stage for NoiseGateStage {
         input * reduction
     }
 
+    /// Clears the level envelope and slams the gate shut with no hold left, the
+    /// same state a freshly constructed gate starts in. Carrying an open gate
+    /// across a seek would leak the first moments of noise through.
+    fn reset(&mut self) {
+        self.envelope.reset();
+        self.gate_state = 0.0;
+        self.hold_counter = 0;
+    }
+
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
         match name {
             "threshold" => {
@@ -189,6 +198,54 @@ mod tests {
     fn make_gate() -> NoiseGateStage {
         // threshold -30 dB, ratio 10:1, 1ms attack, 50ms hold, 50ms release
         NoiseGateStage::new(-30.0, 10.0, 1.0, 50.0, 50.0, SR)
+    }
+
+    /// PLUG-2: a gate left open by loud playing before a seek would let the
+    /// first moments of noise after it through at full level. Reset shuts it.
+    #[test]
+    fn reset_closes_the_gate() {
+        let mut gate = make_gate();
+
+        // Drive it wide open.
+        for _ in 0..(SR as usize / 10) {
+            gate.process(0.8);
+        }
+        assert!(
+            gate.process(0.8) > 0.7,
+            "gate should be open before the reset"
+        );
+
+        gate.reset();
+
+        // First sample after the reset is fully attenuated: envelope at zero,
+        // gate state at zero, no hold left over.
+        let out = gate.process(0.001);
+        assert!(
+            out.abs() <= 0.001 / 10.0 + 1e-9,
+            "gate leaked {out} on the first sample after reset"
+        );
+    }
+
+    /// Reset must reproduce a freshly built gate exactly — envelope, gate state
+    /// and hold counter all back to their initial values.
+    #[test]
+    fn reset_matches_a_fresh_gate() {
+        let mut used = make_gate();
+        for _ in 0..(SR as usize / 10) {
+            used.process(0.8);
+        }
+        used.reset();
+
+        let mut fresh = make_gate();
+        for i in 0..4096 {
+            let input = (i as f32 * 0.05).sin() * 0.5;
+            let a = used.process(input);
+            let b = fresh.process(input);
+            assert!(
+                (a - b).abs() < 1e-9,
+                "sample {i}: reset gate gave {a}, fresh gate {b}"
+            );
+        }
     }
 
     #[test]

--- a/rustortion-core/src/amp/stages/poweramp.rs
+++ b/rustortion-core/src/amp/stages/poweramp.rs
@@ -90,6 +90,14 @@ impl Stage for PowerAmpStage {
         self.dc_blocker.process(clipped)
     }
 
+    /// Clears the sag envelope — otherwise the rail would still be pulled down
+    /// by the chord before the seek, so the first notes after it come back
+    /// compressed — and the output DC blocker.
+    fn reset(&mut self) {
+        self.sag_envelope.reset();
+        self.dc_blocker.reset();
+    }
+
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
         match name {
             "drive" => {

--- a/rustortion-core/src/amp/stages/preamp.rs
+++ b/rustortion-core/src/amp/stages/preamp.rs
@@ -54,6 +54,14 @@ impl Stage for PreampStage {
         self.dc_blocker.process(clipped)
     }
 
+    /// Clears the inter-stage lowpass and the output DC blocker. The
+    /// waveshapers themselves are memoryless, so those two filters are the
+    /// stage's entire state.
+    fn reset(&mut self) {
+        self.interstage_lp.reset();
+        self.dc_blocker.reset();
+    }
+
     fn set_parameter(&mut self, p: &str, v: f32) -> Result<(), &'static str> {
         match p {
             "gain" => {

--- a/rustortion-core/src/amp/stages/reverb.rs
+++ b/rustortion-core/src/amp/stages/reverb.rs
@@ -51,6 +51,13 @@ impl CombFilter {
         output
     }
 
+    /// Empty the comb's delay line and its lowpass memory, keeping the tuning.
+    fn reset(&mut self) {
+        self.buffer.fill(0.0);
+        self.write_pos = 0;
+        self.filterstore = 0.0;
+    }
+
     const fn set_feedback(&mut self, feedback: f32) {
         self.feedback = feedback;
     }
@@ -73,6 +80,12 @@ impl AllpassFilter {
             buffer: vec![0.0; size],
             write_pos: 0,
         }
+    }
+
+    /// Empty the allpass delay line.
+    fn reset(&mut self) {
+        self.buffer.fill(0.0);
+        self.write_pos = 0;
     }
 
     fn process(&mut self, input: f32) -> f32 {
@@ -158,6 +171,18 @@ impl Stage for ReverbStage {
 
         // Dry/wet mix
         (1.0 - self.mix).mul_add(input, self.mix * out)
+    }
+
+    /// Drains the whole tank: all 8 comb delay lines (and their damping
+    /// lowpasses) plus the 4 series allpasses. This is the stage the missing
+    /// reset was most audible on — a Freeverb tail rings for seconds.
+    fn reset(&mut self) {
+        for comb in &mut self.combs {
+            comb.reset();
+        }
+        for allpass in &mut self.allpasses {
+            allpass.reset();
+        }
     }
 
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
@@ -406,6 +431,68 @@ mod tests {
             max_out < 5.0,
             "Output should stay bounded with sustained input, got max {max_out}"
         );
+    }
+
+    /// PLUG-2: a Freeverb tank rings for seconds. On a transport jump that tail
+    /// must be gone, not fading over the new position.
+    #[test]
+    fn reset_drains_the_tank() {
+        let mut reverb = ReverbStage::new(0.9, 0.2, 1.0, SAMPLE_RATE);
+
+        // Excite the tank hard and let it fill.
+        for _ in 0..SAMPLE_RATE as usize / 10 {
+            reverb.process(1.0);
+        }
+        // Sanity: it really is ringing.
+        let ringing = (0..1000)
+            .map(|_| reverb.process(0.0).abs())
+            .fold(0.0_f32, f32::max);
+        assert!(ringing > 1e-4, "tank should be ringing, got {ringing}");
+
+        reverb.reset();
+
+        for i in 0..SAMPLE_RATE as usize {
+            let out = reverb.process(0.0);
+            assert!(
+                out.abs() < 1e-9,
+                "reverb tail survived reset at sample {i}: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn reset_preserves_parameters() {
+        let mut reverb = ReverbStage::new(0.7, 0.3, 0.4, SAMPLE_RATE);
+        reverb.process(1.0);
+        reverb.reset();
+
+        assert!((reverb.get_parameter("room_size").unwrap() - 0.7).abs() < 1e-6);
+        assert!((reverb.get_parameter("damping").unwrap() - 0.3).abs() < 1e-6);
+        assert!((reverb.get_parameter("mix").unwrap() - 0.4).abs() < 1e-6);
+    }
+
+    /// A reset tank must behave exactly like a freshly built one, not merely
+    /// "quiet" — the combs' write cursors and damping memory have to go back to
+    /// their initial positions too, or the next impulse comes out different.
+    #[test]
+    fn reset_matches_a_fresh_stage() {
+        let mut used = ReverbStage::new(0.5, 0.5, 1.0, SAMPLE_RATE);
+        for _ in 0..5000 {
+            used.process(0.7);
+        }
+        used.reset();
+
+        let mut fresh = ReverbStage::new(0.5, 0.5, 1.0, SAMPLE_RATE);
+
+        for i in 0..4096 {
+            let input = if i == 0 { 1.0 } else { 0.0 };
+            let a = used.process(input);
+            let b = fresh.process(input);
+            assert!(
+                (a - b).abs() < 1e-9,
+                "sample {i}: reset stage gave {a}, fresh stage {b}"
+            );
+        }
     }
 
     #[test]

--- a/rustortion-core/src/amp/stages/tonestack.rs
+++ b/rustortion-core/src/amp/stages/tonestack.rs
@@ -162,6 +162,16 @@ impl Stage for ToneStackStage {
         y * 0.7
     }
 
+    /// Zeroes the four one-pole states: the 20 Hz DC blocker, the bass and
+    /// treble shelves, and the presence shelf. Tone-control positions are
+    /// parameters and stay put.
+    fn reset(&mut self) {
+        self.dc_hp = 0.0;
+        self.bass_lp = 0.0;
+        self.treble_lp = 0.0;
+        self.presence_lp = 0.0;
+    }
+
     // -------------------------------------------------------------
     // Parameter management
     // -------------------------------------------------------------

--- a/rustortion-core/src/amp/stages/tremolo.rs
+++ b/rustortion-core/src/amp/stages/tremolo.rs
@@ -122,6 +122,15 @@ impl Stage for TremoloStage {
         input * self.next_gain()
     }
 
+    /// Rewinds the LFO to phase zero and snaps the depth smoother to its
+    /// target. Restarting the sweep at the top of the cycle is what makes a
+    /// tremolo line up with the bar after a locate; the alternative — free
+    /// running phase — puts the chop in a different place on every take.
+    fn reset(&mut self) {
+        self.phase = 0.0;
+        self.depth_smoothed = self.depth;
+    }
+
     fn set_parameter(&mut self, name: &str, value: f32) -> Result<(), &'static str> {
         match name {
             "rate" => {
@@ -289,6 +298,40 @@ mod tests {
                 "stale shape cache at {i}: {oa} vs {ob}"
             );
         }
+    }
+
+    /// PLUG-2: the LFO free-runs, so after a locate the chop would land in a
+    /// different place on every pass. Reset rewinds it to phase zero, which is
+    /// what makes a tremolo repeatable take to take.
+    #[test]
+    fn reset_rewinds_the_lfo() {
+        let mut used = TremoloStage::new(5.0, 0.9, 0.6, SAMPLE_RATE);
+        // Advance the phase to somewhere arbitrary and let depth settle.
+        for _ in 0..7919 {
+            used.process(1.0);
+        }
+        used.reset();
+
+        let mut fresh = TremoloStage::new(5.0, 0.9, 0.6, SAMPLE_RATE);
+        for i in 0..4096 {
+            let a = used.process(1.0);
+            let b = fresh.process(1.0);
+            assert!(
+                (a - b).abs() < TOL,
+                "sample {i}: reset LFO gave {a}, fresh {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn reset_preserves_parameters() {
+        let mut trem = TremoloStage::new(7.0, 0.8, 0.4, SAMPLE_RATE);
+        trem.process(1.0);
+        trem.reset();
+
+        assert!((trem.get_parameter("rate").unwrap() - 7.0).abs() < TOL);
+        assert!((trem.get_parameter("depth").unwrap() - 0.8).abs() < TOL);
+        assert!((trem.get_parameter("shape").unwrap() - 0.4).abs() < TOL);
     }
 
     #[test]

--- a/rustortion-core/src/amp/stages/tremolo.rs
+++ b/rustortion-core/src/amp/stages/tremolo.rs
@@ -123,9 +123,14 @@ impl Stage for TremoloStage {
     }
 
     /// Rewinds the LFO to phase zero and snaps the depth smoother to its
-    /// target. Restarting the sweep at the top of the cycle is what makes a
-    /// tremolo line up with the bar after a locate; the alternative — free
-    /// running phase — puts the chop in a different place on every take.
+    /// target.
+    ///
+    /// Phase zero is the sine's rising zero crossing, so the sweep restarts
+    /// mid-travel at a gain of `1 - depth / 2` — not at the top. The point is
+    /// not musical alignment: the LFO free-runs in Hz with no tempo sync, so it
+    /// cannot line up with a bar. The point is **reproducibility** — rendering
+    /// the same passage twice must give the same chop, and a free-running phase
+    /// would put it somewhere different on every offline bounce.
     fn reset(&mut self) {
         self.phase = 0.0;
         self.depth_smoothed = self.depth;

--- a/rustortion-core/src/audio/engine.rs
+++ b/rustortion-core/src/audio/engine.rs
@@ -276,6 +276,51 @@ impl Engine {
         Ok(())
     }
 
+    /// Drop every sample of audio still in flight anywhere in the signal path,
+    /// without changing a single setting.
+    ///
+    /// This is what a plugin host's transport locate/seek maps onto (nih-plug's
+    /// `Plugin::reset`, which it documents as callable "at any other time from
+    /// the audio thread"). Without it, a seek leaves the delay lines, reverb
+    /// tanks, filter memory, oversampling FIFO, pitch-shifter STFT buffers and
+    /// IR tail full of the audio from wherever the playhead used to be, and you
+    /// hear bar 32 over bar 1.
+    ///
+    /// Covers, in signal order: the input filters, the oversampling resamplers
+    /// and their FIFO, every stage in the amp chain (bypassed ones included),
+    /// the pitch shifter, and the IR cabinet.
+    ///
+    /// # Real-time contract
+    ///
+    /// Runs on the audio thread and is allocation-free, lock-free and I/O-free
+    /// throughout — everything below zeroes buffers in place. It is emphatically
+    /// **not** the engine-rebuild path (`SetAmpChain` and friends), which
+    /// allocates. `tests/no_alloc.rs::reset` enforces this.
+    ///
+    /// Deliberately left alone: the reported latency (nothing here changes it,
+    /// and the audio thread cannot re-report it anyway); the tuner, peak meter,
+    /// metronome and recorder, none of which feed the processed signal path;
+    /// and the diagnostic latches (`nonfinite_seen` and the one-shot event
+    /// fields), which describe the session rather than the audio.
+    pub fn reset(&mut self) {
+        if let Some(ref mut hp) = self.input_highpass {
+            hp.reset();
+        }
+        if let Some(ref mut lp) = self.input_lowpass {
+            lp.reset();
+        }
+
+        self.samplers.reset();
+        self.chain.reset();
+
+        if let Some(ref mut shifter) = self.pitch_shifter {
+            shifter.reset();
+        }
+        if let Some(ref mut cab) = self.ir_cabinet {
+            cab.reset();
+        }
+    }
+
     /// Master-bus safety net: replace any non-finite sample with silence.
     ///
     /// A NaN or infinity produced anywhere upstream (feedback paths in the

--- a/rustortion-core/src/audio/pitch_shifter.rs
+++ b/rustortion-core/src/audio/pitch_shifter.rs
@@ -127,6 +127,43 @@ impl PitchShifter {
         }
     }
 
+    /// Discard all in-flight audio and phase history, returning the vocoder to
+    /// exactly the state [`PitchShifter::new`] leaves it in.
+    ///
+    /// Three separate things have to go, or the shifter smears pre-seek audio
+    /// over the new position for a full frame:
+    /// * the **analysis ring** (`input_ring`), which still holds up to
+    ///   `FFT_SIZE` samples of the old material, plus its write cursor and the
+    ///   partial hop in `hop_counter`;
+    /// * the **overlap-add output** (`output_accum`), which holds already
+    ///   synthesised frames waiting to be read, and its read/write cursors —
+    ///   `output_write` goes back to `HOP_SIZE` ahead of `output_read`, the
+    ///   spacing `new` establishes and `process_frame` maintains;
+    /// * the **phase state** (`last_phase` / `accum_phase`), meaningless once
+    ///   the signal is discontinuous; `first_frame` re-seeds the accumulator
+    ///   from the next frame's analysis phase instead of integrating from
+    ///   stale values, which is what avoids a startup smear.
+    ///
+    /// The scratch buffers (`frame`, `spectrum`, `shifted`, …) are not cleared:
+    /// each is fully overwritten before it is read within a single
+    /// `process_frame`.
+    ///
+    /// RT-safe: fills and index assignments only, no reallocation, and the
+    /// reported latency (one FFT frame) is unchanged.
+    pub fn reset(&mut self) {
+        self.input_ring.fill(0.0);
+        self.input_pos = 0;
+        self.hop_counter = 0;
+
+        self.output_accum.fill(0.0);
+        self.output_read = 0;
+        self.output_write = HOP_SIZE;
+
+        self.last_phase.fill(0.0);
+        self.accum_phase.fill(0.0);
+        self.first_frame = true;
+    }
+
     /// Update the pitch ratio without reallocating buffers.
     pub fn set_semitones(&mut self, semitones: f32) {
         self.ratio = (semitones as f64 / 12.0).exp2();

--- a/rustortion-core/src/audio/samplers.rs
+++ b/rustortion-core/src/audio/samplers.rs
@@ -80,10 +80,29 @@ impl BlockFifo {
     /// Start buffering. Allocation-free by construction: both `Vec`s were sized
     /// in `new` and are only written to here.
     fn engage(&mut self) {
-        self.input_len = 0;
-        self.output[..self.prefill].fill(0.0);
-        self.output_len = self.prefill;
         self.engaged = true;
+        self.reset();
+    }
+
+    /// Drop every queued frame, leaving the FIFO as it was the moment it
+    /// engaged (or, if it never engaged, empty).
+    ///
+    /// Deliberately does **not** change `engaged`. That flag is sticky because
+    /// every transition re-reports latency to the host, and reset runs on the
+    /// audio thread where no latency can be re-reported — so an engaged FIFO is
+    /// re-primed with its full pre-fill of silence rather than emptied, keeping
+    /// [`Samplers::latency_frames`] invariant across the reset.
+    ///
+    /// Only lengths and the pre-fill region are touched; frames past
+    /// `input_len` / `output_len` are never read. Allocation-free.
+    fn reset(&mut self) {
+        self.input_len = 0;
+        if self.engaged {
+            self.output[..self.prefill].fill(0.0);
+            self.output_len = self.prefill;
+        } else {
+            self.output_len = 0;
+        }
     }
 }
 
@@ -363,6 +382,32 @@ impl Samplers {
         output[n..].fill(0.0);
         fifo.output.copy_within(n..fifo.output_len, 0);
         fifo.output_len -= n;
+    }
+
+    /// Drop all in-flight audio: the two resamplers' overlap/scratch state, the
+    /// staging buffers, and anything queued in the variable-block FIFO.
+    ///
+    /// RT-safe. `rubato`'s `Fft::reset` only zero-fills buffers it already owns
+    /// (and `update_chunk_sizes` is a no-op for `FixedSync::Both`, which is how
+    /// both resamplers here are built), and the FIFO reset is lengths plus a
+    /// fill of memory allocated in `new`.
+    ///
+    /// The reported latency is unchanged by design — see [`BlockFifo::reset`].
+    pub fn reset(&mut self) {
+        self.upsampler.reset();
+        self.downsampler.reset();
+
+        self.input_buffer[0].fill(0.0);
+        self.upsampled_buffer[0].fill(0.0);
+        self.downsampled_buffer[0].fill(0.0);
+        // Matches `new`: until the next `upsample()` sets it, treat the whole
+        // (now silent) buffer as valid so a stray `downsample()` reads zeros
+        // rather than a stale frame count into stale audio.
+        self.upsampled_frames = self.upsampled_buffer[0].len();
+
+        if let Some(fifo) = self.fifo.as_mut() {
+            fifo.reset();
+        }
     }
 
     pub fn resize_buffers(&mut self, new_size: usize) -> Result<()> {

--- a/rustortion-core/src/ir/cabinet.rs
+++ b/rustortion-core/src/ir/cabinet.rs
@@ -94,6 +94,16 @@ impl IrCabinet {
         conv_out * self.output_gain
     }
 
+    /// Zero the convolver's delay line, dropping the cab's ringing tail while
+    /// keeping the loaded IR (unlike [`Self::clear_convolver`], which discards
+    /// the coefficients too).
+    ///
+    /// RT-safe: `Convolver::reset` allocates and frees nothing on either
+    /// implementation.
+    pub fn reset(&mut self) {
+        self.convolver.reset();
+    }
+
     pub fn set_bypass(&mut self, bypass: bool) {
         self.bypassed = bypass;
         if bypass {

--- a/rustortion-core/tests/engine_factory.rs
+++ b/rustortion-core/tests/engine_factory.rs
@@ -603,3 +603,324 @@ mod variable_block_and_guards {
         );
     }
 }
+
+/// PLUG-2: `Engine::reset` — what nih-plug's `Plugin::reset` (transport
+/// locate/seek) maps onto. Everything holding audio in flight has to be
+/// flushed, and nothing that describes the *configuration* may move.
+mod reset {
+    use rustortion_core::amp::chain::AmplifierChain;
+    use rustortion_core::amp::stages::delay::DelayStage;
+    use rustortion_core::amp::stages::filter::{FilterStage, FilterType};
+    use rustortion_core::amp::stages::reverb::ReverbStage;
+    use rustortion_core::audio::engine::Engine;
+    use rustortion_core::audio::pitch_shifter::PitchShifter;
+    use rustortion_core::audio::samplers::Samplers;
+    use rustortion_core::ir::cabinet::{ConvolverType, IrCabinet};
+    use rustortion_core::ir::convolver::Convolver;
+
+    const SR: usize = 48_000;
+    const SR_F32: f32 = 48_000.0;
+    const BLOCK: usize = 64;
+
+    /// Decaying IR, long enough to have an audible tail of its own.
+    fn test_ir() -> Vec<f32> {
+        (0..1024)
+            .map(|i| (-(i as f32) / 128.0).exp() * 0.5)
+            .collect()
+    }
+
+    fn cabinet_with_ir() -> IrCabinet {
+        let mut cab = IrCabinet::new(ConvolverType::Fir, SR * 50 / 1000);
+        let mut conv = Convolver::new_fir(SR * 50 / 1000);
+        conv.set_ir(&test_ir()).unwrap();
+        cab.set_convolver(conv);
+        cab.set_gain(1.0);
+        cab
+    }
+
+    /// Largest absolute sample the engine emits over `blocks` blocks of silence.
+    fn peak_over_silence(engine: &mut Engine, blocks: usize) -> f32 {
+        let input = vec![0.0_f32; BLOCK];
+        let mut output = vec![0.0_f32; BLOCK];
+        let mut peak = 0.0_f32;
+        for _ in 0..blocks {
+            engine.process(&input, &mut output).unwrap();
+            for &s in &output {
+                peak = peak.max(s.abs());
+            }
+        }
+        peak
+    }
+
+    /// The headline bug: seek in a DAW with a reverb or delay in the chain and
+    /// you hear the tail from bar 32 over bar 1.
+    #[test]
+    fn reset_silences_delay_and_reverb_tails() {
+        let (mut engine, handle, _rx) =
+            Engine::new_for_plugin(SR, BLOCK, None, 1.0).expect("engine should construct");
+
+        let mut chain = AmplifierChain::new();
+        chain.add_stage(Box::new(DelayStage::new(120.0, 0.9, 1.0, SR_F32)));
+        chain.add_stage(Box::new(ReverbStage::new(0.9, 0.2, 1.0, SR_F32)));
+        handle.set_amp_chain(chain);
+
+        // Play something loud, then stop.
+        let loud = vec![0.8_f32; BLOCK];
+        let mut output = vec![0.0_f32; BLOCK];
+        for _ in 0..200 {
+            engine.process(&loud, &mut output).unwrap();
+        }
+
+        // Without a reset, the tail is plainly audible.
+        assert!(
+            peak_over_silence(&mut engine, 20) > 1e-3,
+            "the chain should be ringing before the reset — the test proves nothing otherwise"
+        );
+
+        engine.reset();
+
+        let peak = peak_over_silence(&mut engine, 400);
+        assert!(
+            peak < 1e-9,
+            "audio from before the seek survived the reset: peak {peak}"
+        );
+    }
+
+    /// The IR cabinet's convolution tail is part of the same problem.
+    #[test]
+    fn reset_silences_the_ir_tail() {
+        let (mut engine, _handle, _rx) =
+            Engine::new_for_plugin(SR, BLOCK, Some(cabinet_with_ir()), 1.0)
+                .expect("engine should construct");
+
+        let loud = vec![0.8_f32; BLOCK];
+        let mut output = vec![0.0_f32; BLOCK];
+        for _ in 0..40 {
+            engine.process(&loud, &mut output).unwrap();
+        }
+        assert!(
+            peak_over_silence(&mut engine, 1) > 1e-4,
+            "the cab should be ringing before the reset"
+        );
+
+        engine.reset();
+
+        let peak = peak_over_silence(&mut engine, 40);
+        assert!(peak < 1e-9, "IR tail survived the reset: peak {peak}");
+    }
+
+    /// The oversampling resamplers and the input filters hold state of their
+    /// own, upstream and downstream of the chain.
+    #[test]
+    fn reset_flushes_the_oversampling_path_and_input_filters() {
+        let (mut engine, handle, _rx) =
+            Engine::new_for_plugin(SR, BLOCK, None, 4.0).expect("engine should construct");
+
+        handle.set_input_filters(
+            Some(Box::new(FilterStage::new(
+                FilterType::Highpass,
+                80.0,
+                SR_F32,
+            ))),
+            Some(Box::new(FilterStage::new(
+                FilterType::Lowpass,
+                8_000.0,
+                SR_F32,
+            ))),
+        );
+
+        let loud = vec![0.9_f32; BLOCK];
+        let mut output = vec![0.0_f32; BLOCK];
+        for _ in 0..40 {
+            engine.process(&loud, &mut output).unwrap();
+        }
+        assert!(
+            peak_over_silence(&mut engine, 1) > 1e-4,
+            "resampler/filter state should be non-empty before the reset"
+        );
+
+        engine.reset();
+
+        let peak = peak_over_silence(&mut engine, 40);
+        assert!(
+            peak < 1e-9,
+            "oversampling/input-filter state survived the reset: peak {peak}"
+        );
+    }
+
+    /// The pitch shifter buffers a full FFT frame of audio plus an overlap-add
+    /// tail, so a seek without a reset smears the old position over the new one
+    /// for ~42 ms.
+    #[test]
+    fn reset_flushes_the_pitch_shifter() {
+        let (mut engine, handle, _rx) =
+            Engine::new_for_plugin(SR, BLOCK, None, 1.0).expect("engine should construct");
+        handle.set_pitch_shift(7);
+
+        let loud = vec![0.8_f32; BLOCK];
+        let mut output = vec![0.0_f32; BLOCK];
+        for _ in 0..200 {
+            engine.process(&loud, &mut output).unwrap();
+        }
+        assert!(
+            peak_over_silence(&mut engine, 4) > 1e-4,
+            "the shifter should have audio in flight before the reset"
+        );
+
+        engine.reset();
+
+        let peak = peak_over_silence(&mut engine, 200);
+        assert!(
+            peak < 1e-9,
+            "pitch shifter output survived the reset: peak {peak}"
+        );
+    }
+
+    /// A reset shifter must behave like a fresh one, not merely be quiet — the
+    /// ring cursor, hop counter and overlap-add pointers all have to go back to
+    /// their initial positions or the next frame comes out different.
+    #[test]
+    fn pitch_shifter_reset_matches_a_fresh_shifter() {
+        let mut used = PitchShifter::new(7.0);
+        let mut warm: Vec<f32> = (0..8192).map(|i| (i as f32 * 0.03).sin()).collect();
+        used.process_block(&mut warm);
+        used.reset();
+
+        let mut fresh = PitchShifter::new(7.0);
+
+        let probe: Vec<f32> = (0..8192).map(|i| (i as f32 * 0.017).sin() * 0.6).collect();
+        let mut a = probe.clone();
+        let mut b = probe;
+        used.process_block(&mut a);
+        fresh.process_block(&mut b);
+
+        for (i, (x, y)) in a.iter().zip(&b).enumerate() {
+            assert!(
+                (x - y).abs() < 1e-6,
+                "sample {i}: reset shifter gave {x}, fresh shifter {y}"
+            );
+        }
+    }
+
+    /// Reset runs on the audio thread, where latency cannot be re-reported. So
+    /// it must not change the figure the host was already told — in particular
+    /// it must not disengage the sticky oversampling FIFO.
+    #[test]
+    fn reset_preserves_reported_latency() {
+        for oversample in [1.0, 4.0] {
+            let (mut engine, handle, _rx) =
+                Engine::new_for_plugin(SR, 512, None, oversample).expect("engine should construct");
+            handle.set_pitch_shift(7);
+
+            let input = vec![0.5_f32; 512];
+            let mut output = vec![0.0_f32; 512];
+            engine.process(&input, &mut output).unwrap();
+
+            // A ragged block engages the FIFO permanently (4x only).
+            let ragged = vec![0.5_f32; 37];
+            let mut ragged_out = vec![0.0_f32; 37];
+            engine.process(&ragged, &mut ragged_out).unwrap();
+
+            let engaged_before = engine.fifo_engaged();
+            let latency_before = engine.latency_frames();
+
+            engine.reset();
+
+            assert_eq!(
+                engine.latency_frames(),
+                latency_before,
+                "{oversample}x: reset changed the reported latency"
+            );
+            assert_eq!(
+                engine.fifo_engaged(),
+                engaged_before,
+                "{oversample}x: reset changed FIFO engagement"
+            );
+        }
+    }
+
+    /// Reset is state-only: every setting must survive it.
+    #[test]
+    fn reset_preserves_configuration() {
+        let (mut engine, handle, _rx) =
+            Engine::new_for_plugin(SR, BLOCK, Some(cabinet_with_ir()), 1.0)
+                .expect("engine should construct");
+
+        let mut chain = AmplifierChain::new();
+        chain.add_stage(Box::new(DelayStage::new(250.0, 0.5, 0.4, SR_F32)));
+        handle.set_amp_chain(chain);
+
+        let input = vec![0.5_f32; BLOCK];
+        let mut output = vec![0.0_f32; BLOCK];
+        engine.process(&input, &mut output).unwrap();
+
+        let tail_before = engine.tail_seconds();
+        assert!(tail_before > 0.0, "the delay should report a tail");
+
+        engine.reset();
+        engine.process(&input, &mut output).unwrap();
+
+        assert_eq!(
+            engine.tail_seconds(),
+            tail_before,
+            "reset must not disturb the reported tail — the chain is unchanged"
+        );
+    }
+
+    /// Reset is idempotent and safe on an engine that has never processed a
+    /// block: hosts are free to call it right after `initialize()`, and
+    /// nih-plug in fact always does.
+    #[test]
+    fn reset_is_safe_before_any_audio_and_when_repeated() {
+        let (mut engine, _handle, _rx) =
+            Engine::new_for_plugin(SR, BLOCK, Some(cabinet_with_ir()), 4.0)
+                .expect("engine should construct");
+
+        engine.reset();
+        engine.reset();
+
+        let input = vec![0.5_f32; BLOCK];
+        let mut output = vec![0.0_f32; BLOCK];
+        engine.process(&input, &mut output).unwrap();
+        assert!(
+            output.iter().all(|s| s.is_finite()),
+            "engine produced non-finite output after an early reset"
+        );
+    }
+
+    /// `Samplers::reset` in isolation, including that it leaves the resamplers
+    /// usable (rubato's `reset` also restores chunk sizes).
+    #[test]
+    fn samplers_reset_leaves_them_usable() {
+        let mut samplers = Samplers::new(BLOCK, 4.0, SR).unwrap();
+        let latency_before = samplers.latency_frames();
+
+        samplers.copy_input(&vec![0.7_f32; BLOCK]).unwrap();
+        samplers.upsample().unwrap();
+        samplers.downsample().unwrap();
+
+        samplers.reset();
+
+        assert_eq!(
+            samplers.latency_frames(),
+            latency_before,
+            "reset changed the samplers' reported latency"
+        );
+
+        // Silence in must now give silence out: nothing of the old block is
+        // left in the overlap buffers.
+        let mut peak = 0.0_f32;
+        for _ in 0..8 {
+            samplers.copy_input(&vec![0.0_f32; BLOCK]).unwrap();
+            samplers.upsample().unwrap();
+            let out = samplers.downsample().unwrap();
+            for &s in out.iter() {
+                peak = peak.max(s.abs());
+            }
+        }
+        assert!(
+            peak < 1e-9,
+            "resampler state survived the reset: peak {peak}"
+        );
+    }
+}

--- a/rustortion-core/tests/engine_factory.rs
+++ b/rustortion-core/tests/engine_factory.rs
@@ -640,8 +640,13 @@ mod reset {
 
     /// Largest absolute sample the engine emits over `blocks` blocks of silence.
     fn peak_over_silence(engine: &mut Engine, blocks: usize) -> f32 {
-        let input = vec![0.0_f32; BLOCK];
-        let mut output = vec![0.0_f32; BLOCK];
+        peak_over_silence_blocks(engine, BLOCK, blocks)
+    }
+
+    /// As [`peak_over_silence`], for engines built around a different block size.
+    fn peak_over_silence_blocks(engine: &mut Engine, block: usize, blocks: usize) -> f32 {
+        let input = vec![0.0_f32; block];
+        let mut output = vec![0.0_f32; block];
         let mut peak = 0.0_f32;
         for _ in 0..blocks {
             engine.process(&input, &mut output).unwrap();
@@ -837,6 +842,89 @@ mod reset {
                 "{oversample}x: reset changed FIFO engagement"
             );
         }
+    }
+
+    /// The engaged variable-block FIFO is the riskiest thing `reset` touches.
+    /// `BlockFifo::reset` deliberately re-primes the pre-fill instead of
+    /// emptying the queue, because the audio thread cannot re-report latency —
+    /// and that has to leave the stream *aligned*, not merely quiet. The other
+    /// reset tests never reach this path: their blocks are exact multiples of
+    /// the resampler chunk, so they stay on the zero-latency fast path forever.
+    ///
+    /// Emptying the FIFO instead of re-priming it would shift everything after
+    /// the seek by `max_block + chunk` frames against the latency the host was
+    /// already told about, which is exactly what the impulse assertion catches.
+    #[test]
+    fn reset_keeps_the_engaged_fifo_aligned() {
+        const MAX_BLOCK: usize = 512;
+
+        let (mut engine, _handle, _rx) =
+            Engine::new_for_plugin(SR, MAX_BLOCK, None, 4.0).expect("engine should construct");
+
+        let silence = vec![0.0_f32; MAX_BLOCK];
+        let mut out = vec![0.0_f32; MAX_BLOCK];
+        engine.process(&silence, &mut out).unwrap();
+
+        // A ragged block engages the FIFO permanently.
+        let ragged = vec![0.0_f32; 37];
+        let mut ragged_out = vec![0.0_f32; 37];
+        engine.process(&ragged, &mut ragged_out).unwrap();
+        assert!(
+            engine.fifo_engaged(),
+            "the ragged block should have engaged the FIFO"
+        );
+
+        // Load the FIFO and both resamplers up with loud audio, then seek.
+        let loud = vec![0.85_f32; MAX_BLOCK];
+        for _ in 0..20 {
+            engine.process(&loud, &mut out).unwrap();
+        }
+
+        let latency = engine.latency_frames();
+        engine.reset();
+        assert_eq!(
+            engine.latency_frames(),
+            latency,
+            "reset changed the latency the host was told about"
+        );
+
+        // Silence in, silence out — from the very first block. Nothing of the
+        // loud pre-seek audio is left queued in the FIFO or held in the
+        // resamplers' overlap buffers.
+        let leak = peak_over_silence_blocks(&mut engine, MAX_BLOCK, 20);
+        assert!(
+            leak < 1e-9,
+            "pre-seek audio survived the reset: peak {leak}"
+        );
+
+        // Feed an impulse into the now-quiet pipeline.
+        let mut stream = vec![0.0_f32; MAX_BLOCK * 20];
+        stream[0] = 1.0;
+        let mut got = Vec::with_capacity(stream.len());
+        for block in stream.chunks(MAX_BLOCK) {
+            engine.process(block, &mut out).unwrap();
+            got.extend_from_slice(&out);
+        }
+
+        // It comes back at exactly the reported latency. (The resamplers are
+        // linear phase, so the main lobe straddles that centre — hence the peak
+        // position rather than the first non-zero sample.)
+        let (peak_at, peak) =
+            got.iter()
+                .enumerate()
+                .fold((0_usize, 0.0_f32), |(best_i, best), (i, &s)| {
+                    if s.abs() > best {
+                        (i, s.abs())
+                    } else {
+                        (best_i, best)
+                    }
+                });
+        assert!(peak > 0.1, "the impulse never arrived: peak {peak}");
+        assert!(
+            peak_at.abs_diff(latency) <= 1,
+            "impulse landed at {peak_at}, expected the reported latency {latency} — \
+             the FIFO was left half-primed"
+        );
     }
 
     /// Reset is state-only: every setting must survive it.

--- a/rustortion-core/tests/no_alloc.rs
+++ b/rustortion-core/tests/no_alloc.rs
@@ -336,6 +336,280 @@ mod stages {
 }
 
 // ---------------------------------------------------------------------------
+// Reset path (PLUG-2)
+// ---------------------------------------------------------------------------
+
+mod reset {
+    //! `Stage::reset` and `Engine::reset` exist because nih-plug calls
+    //! `Plugin::reset` on transport locate — and it documents that as callable
+    //! "at any other time from the audio thread". So the whole reset path is RT
+    //! path: it must zero state **in place** and must never be wired to the
+    //! engine-rebuild machinery, which allocates.
+    //!
+    //! Every stage is exercised with real audio *before* the audit, so each one
+    //! has genuine state to clear rather than trivially-already-zero buffers.
+
+    use super::*;
+    use rustortion_core::amp::stages::nam::NamConfig;
+
+    /// One live instance of every `Stage` impl in the workspace. Kept exhaustive
+    /// by hand; `Stage::reset` is a required trait method, so a new stage cannot
+    /// silently skip `reset` itself, but it *can* skip this audit — hence the
+    /// count assertion below.
+    fn all_stages() -> Vec<Box<dyn Stage>> {
+        vec![
+            Box::new(PreampStage::new(
+                5.0,
+                0.2,
+                ClipperType::Asymmetric,
+                SAMPLE_RATE_F32,
+            )),
+            Box::new(CompressorStage::new(
+                1.0,
+                50.0,
+                -20.0,
+                4.0,
+                0.0,
+                SAMPLE_RATE_F32,
+            )),
+            Box::new(ToneStackStage::new(
+                ToneStackModel::British,
+                1.2,
+                0.8,
+                1.4,
+                1.0,
+                SAMPLE_RATE_F32,
+            )),
+            Box::new(PowerAmpStage::new(
+                0.5,
+                PowerAmpType::ClassAB,
+                0.6,
+                80.0,
+                SAMPLE_RATE_F32,
+            )),
+            Box::new(LevelStage::new(0.5)),
+            Box::new(NoiseGateStage::new(
+                -30.0,
+                10.0,
+                1.0,
+                50.0,
+                50.0,
+                SAMPLE_RATE_F32,
+            )),
+            Box::new(MultibandSaturatorStage::new(
+                0.5,
+                0.5,
+                0.5,
+                1.0,
+                1.0,
+                1.0,
+                200.0,
+                2000.0,
+                SAMPLE_RATE_F32,
+            )),
+            // Passthrough NAM stage: no `.nam` file on disk in CI, so this
+            // covers the `model: None` arm. The loaded arm delegates straight
+            // to `nam_rs::Model::reset`, which nam-rs audits on its own side.
+            Box::new(NamConfig::default().to_stage(SAMPLE_RATE_F32)),
+            Box::new(DelayStage::new(250.0, 0.4, 0.5, SAMPLE_RATE_F32)),
+            Box::new(ReverbStage::new(0.7, 0.4, 0.5, SAMPLE_RATE_F32)),
+            Box::new(EqStage::new([3.0; NUM_BANDS], SAMPLE_RATE_F32)),
+            Box::new(TremoloStage::new(5.0, 0.7, 0.5, SAMPLE_RATE_F32)),
+            // Not in the GUI stage registry, but it is a `Stage` impl and the
+            // engine runs two of them as the input filters.
+            Box::new(FilterStage::new(
+                FilterType::Highpass,
+                80.0,
+                SAMPLE_RATE_F32,
+            )),
+        ]
+    }
+
+    #[test]
+    fn stage_reset_does_not_allocate() {
+        // Covers: `Stage::reset` on every impl. Buffer-backed stages (delay
+        // ring, reverb combs/allpasses) must `fill(0.0)` rather than
+        // reallocate; the rest are field assignments.
+        let mut stages = all_stages();
+        assert_eq!(
+            stages.len(),
+            13,
+            "all_stages() is out of date — every `impl Stage` must be audited here"
+        );
+
+        // Load every stage up with real state first, so `reset` has something
+        // to clear. Done outside the audit: `process_block` is covered by the
+        // per-stage tests above.
+        let mut block: Vec<f32> = (0..BUFFER_SIZE)
+            .map(|i| (i as f32 * 0.11).sin() * 0.8)
+            .collect();
+        for stage in &mut stages {
+            for _ in 0..8 {
+                stage.process_block(&mut block);
+            }
+        }
+
+        let violations = check_no_alloc(|| {
+            for stage in &mut stages {
+                stage.reset();
+            }
+        });
+        assert_eq!(
+            violations, 0,
+            "Stage::reset allocated {violations} time(s) on the RT path"
+        );
+    }
+
+    #[test]
+    fn chain_reset_does_not_allocate() {
+        // Covers: AmplifierChain::reset walking every stage, bypassed included.
+        let mut chain = AmplifierChain::new();
+        for stage in all_stages() {
+            chain.add_stage(stage);
+        }
+        chain.set_bypassed(0, true);
+
+        let mut block = vec![0.4_f32; BUFFER_SIZE];
+        chain.process_block(&mut block);
+
+        let violations = check_no_alloc(|| chain.reset());
+        assert_eq!(
+            violations, 0,
+            "AmplifierChain::reset allocated {violations} time(s) on the RT path"
+        );
+    }
+
+    /// Build a plugin engine with as much stateful machinery installed as
+    /// possible — oversampling resamplers, a loaded IR cabinet, a pitch shifter,
+    /// input filters and a chain of buffer-backed stages — then run audio
+    /// through it so every buffer holds something.
+    fn loaded_engine(
+        oversample: f64,
+    ) -> (Engine, EngineHandle, RtDropReceiver, Vec<f32>, Vec<f32>) {
+        let max_ir_samples = (SAMPLE_RATE * DEFAULT_MAX_IR_MS) / 1000;
+        let mut cabinet = IrCabinet::new(ConvolverType::Fir, max_ir_samples);
+        cabinet.set_convolver(make_fir_convolver());
+
+        let (mut engine, handle, rx) = plugin_engine_with_ir(oversample, cabinet);
+
+        let mut chain = AmplifierChain::new();
+        for stage in all_stages() {
+            chain.add_stage(stage);
+        }
+        handle.set_amp_chain(chain);
+        handle.set_input_filters(
+            Some(Box::new(FilterStage::new(
+                FilterType::Highpass,
+                80.0,
+                SAMPLE_RATE_F32,
+            ))),
+            Some(Box::new(FilterStage::new(
+                FilterType::Lowpass,
+                8000.0,
+                SAMPLE_RATE_F32,
+            ))),
+        );
+        // Built off the RT thread inside the handle, like the GUI would.
+        handle.set_pitch_shift(7);
+
+        let (input, mut output) = buffers();
+        // Drain the queued messages and fill every buffer with real audio,
+        // outside any audit.
+        for _ in 0..8 {
+            engine.process(&input, &mut output).unwrap();
+        }
+        (engine, handle, rx, input, output)
+    }
+
+    #[test]
+    fn engine_reset_does_not_allocate() {
+        // Covers: the full Engine::reset fan-out — input filters, samplers
+        // (rubato resampler state + staging buffers), chain, pitch shifter
+        // (STFT ring + overlap-add + phase state), IR cabinet delay line.
+        // Asserted at 1x so the resamplers are bypassed by the engine but
+        // still reset, and with several blocks of steady state afterwards so a
+        // reset that left the engine in a state needing re-allocation on the
+        // next block would still be caught.
+        let (mut engine, _handle, _rx, input, mut output) = loaded_engine(1.0);
+
+        let violations = check_no_alloc(|| {
+            for _ in 0..4 {
+                engine.reset();
+                for _ in 0..4 {
+                    engine.process(&input, &mut output).unwrap();
+                }
+            }
+        });
+        assert_eq!(
+            violations, 0,
+            "Engine::reset allocated {violations} time(s) on the RT path"
+        );
+    }
+
+    #[test]
+    fn engine_reset_with_oversampling_does_not_allocate() {
+        // Covers: `Samplers::reset` for real — `rubato`'s `Fft::reset` zeroes
+        // overlap/scratch buffers it already owns, and `update_chunk_sizes` is
+        // a no-op for the `FixedSync::Both` resamplers built here.
+        let (mut engine, _handle, _rx, input, mut output) = loaded_engine(4.0);
+
+        let violations = check_no_alloc(|| {
+            for _ in 0..4 {
+                engine.reset();
+                for _ in 0..4 {
+                    engine.process(&input, &mut output).unwrap();
+                }
+            }
+        });
+        assert_eq!(
+            violations, 0,
+            "Engine::reset at 4x allocated {violations} time(s) on the RT path"
+        );
+    }
+
+    #[test]
+    fn engine_reset_with_engaged_fifo_does_not_allocate() {
+        // Covers: `BlockFifo::reset`, which re-primes the pre-fill (a fill of
+        // memory owned since `new_variable_block`) rather than emptying the
+        // FIFO, so the latency it implies survives the reset.
+        let (mut engine, _handle, _rx, _input, _output) = loaded_engine(4.0);
+
+        // A ragged block engages the FIFO permanently — outside the audit,
+        // since engagement itself is covered by its own test above.
+        let ragged = vec![0.5_f32; 37];
+        let mut ragged_out = vec![0.0_f32; 37];
+        for _ in 0..4 {
+            engine.process(&ragged, &mut ragged_out).unwrap();
+        }
+        assert!(
+            engine.fifo_engaged(),
+            "the ragged block should have engaged"
+        );
+
+        let latency_before = engine.latency_frames();
+        let violations = check_no_alloc(|| {
+            for _ in 0..4 {
+                engine.reset();
+                for _ in 0..4 {
+                    engine.process(&ragged, &mut ragged_out).unwrap();
+                }
+            }
+        });
+        assert_eq!(
+            violations, 0,
+            "Engine::reset with an engaged FIFO allocated {violations} time(s) on the RT path"
+        );
+        assert!(engine.fifo_engaged(), "reset must not disengage the FIFO");
+        assert_eq!(
+            engine.latency_frames(),
+            latency_before,
+            "reset must not change the latency the host was told about — the \
+             audio thread has no way to re-report it"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // IR cabinet tests
 // ---------------------------------------------------------------------------
 

--- a/rustortion-plugin/src/lib.rs
+++ b/rustortion-plugin/src/lib.rs
@@ -559,6 +559,13 @@ impl Plugin for RustortionPlugin {
         context: &mut impl InitContext<Self>,
     ) -> bool {
         self.reported.reset();
+        // REV-24: the engine built below starts with its own default IR gain,
+        // so the `process()` delta check must fire on the very first block to
+        // push the real parameter value into it. A sentinel no gain can equal
+        // guarantees that; carrying the previous activation's value over is
+        // what used to swallow the correction after a reload. (`NEG_INFINITY`,
+        // not `NAN` — a `NaN` comparison is false and would swallow it again.)
+        self.last_ir_gain = f32::NEG_INFINITY;
         self.sample_rate = buffer_config.sample_rate;
         self.shared
             .sample_rate
@@ -926,6 +933,19 @@ impl Plugin for RustortionPlugin {
         // tails on transport stop. `tail_status` reports `Normal` only when
         // there is genuinely nothing left to hear.
         self.tail_status()
+    }
+
+    /// Flush every delay line, filter, buffer and tail in the engine.
+    ///
+    /// nih-plug calls this after each `initialize()` and "at any other time
+    /// from the audio thread" — in practice, whenever the host relocates the
+    /// transport. `Engine::reset` is written to that contract: it zeroes state
+    /// in place and never allocates, locks, or does I/O, so this must not be
+    /// rerouted through the engine-rebuild path.
+    fn reset(&mut self) {
+        if let Some(engine) = self.engine.as_mut() {
+            engine.reset();
+        }
     }
 
     fn deactivate(&mut self) {

--- a/rustortion-plugin/src/lib.rs
+++ b/rustortion-plugin/src/lib.rs
@@ -561,8 +561,8 @@ impl Plugin for RustortionPlugin {
         self.reported.reset();
         // REV-24: the engine built below starts with its own default IR gain,
         // so the `process()` delta check must fire on the very first block to
-        // push the real parameter value into it. A sentinel no gain can equal
-        // guarantees that; carrying the previous activation's value over is
+        // push the real parameter value into it. A sentinel that no gain can
+        // equal guarantees that; carrying the previous activation's value over is
         // what used to swallow the correction after a reload. (`NEG_INFINITY`,
         // not `NAN` — a `NaN` comparison is false and would swallow it again.)
         self.last_ir_gain = f32::NEG_INFINITY;


### PR DESCRIPTION
Closes PLUG-2, promoted into the v0.3.0 gate, plus the one-line slice of REV-24.

## The bug

nih-plug calls `reset()` after every `initialize()` and "at any other time from the audio thread" — hosts use it on transport locate/seek. The plugin never implemented it, so delay lines, reverb tanks, filter memory, the oversampling FIFO and the pitch shifter's STFT buffers all rang across a seek. Seek in a DAW with a reverb or delay in the chain and you hear the tail from bar 32 over bar 1.

The deactivate path masked this by accident — `initialize()` throws the engine away and builds a new one — but nothing masked a plain transport jump. Seeking is the single most common thing anyone does in a DAW.

## The approach

`Stage::reset()` is a **required** trait method, not defaulted. A default empty body would have compiled fine and silently left every stateful stage broken; making it required forced the compiler to enumerate all 13 impls.

| Stage | Cleared |
|---|---|
| level | nothing — memoryless |
| filter | `prev_input`, `prev_output` |
| delay | ring buffer + `write_pos`; time smoother snapped to target |
| reverb | 8 comb lines + damping memory, 4 allpass lines |
| eq | 64 DF1 registers (band gains are coefficients, untouched) |
| compressor | envelope |
| noise_gate | envelope, `gate_state`, `hold_counter` |
| tremolo | LFO phase, depth smoother |
| tonestack | `dc_hp`, `bass_lp`, `treble_lp`, `presence_lp` |
| preamp | interstage LP + DC blocker |
| poweramp | sag envelope + DC blocker |
| multiband_saturator | 6 LR4 filters, 3 envelopes, 3 DC blockers |
| nam | `Model::reset()` |

## Two design calls worth review

**The FIFO stays engaged.** `engaged` is sticky by design — every transition re-reports latency and restarts host playback, and reset runs on the audio thread where latency *cannot* be re-reported. So `BlockFifo::reset` deliberately does not touch it; an engaged FIFO is re-primed with its full pre-fill of silence rather than emptied. `latency_frames()` is therefore invariant across a reset, asserted in two tests.

**The pitch shifter needs three separate clears** or it smears for a full frame: the analysis ring, the overlap-add output (with `output_write` restored to `HOP_SIZE` ahead of `output_read`, the spacing `new` establishes), and the phase state (`first_frame = true` so the accumulator re-seeds from analysis phase instead of integrating stale values). `set_semitones` is left alone — a pitch change shouldn't dump the output tail.

## RT safety

`reset()` is callable from the audio thread, so it zeroes in place and never touches the rebuild path. rubato's `Fft::reset` is allocation-free for `FixedSync::Both`, which is how both resamplers are built.

## REV-24 one-liner

`self.last_ir_gain = f32::NEG_INFINITY;` in `initialize()`, so the delta check stops swallowing the correction and IR gain re-asserts after a reload. `NAN` would **not** work here — `(NAN - x).abs() > EPSILON` is false, so it would swallow the correction again. Nothing else in REV-24 is touched.

## Tests

+28, including a `reset` module in `no_alloc.rs`: `Stage::reset` on all 13 impls with an exhaustiveness count assertion, `AmplifierChain::reset`, and `Engine::reset` at 1x, 4x and with the FIFO engaged — each followed by steady-state blocks, so a reset that leaves the engine needing to reallocate next block is also caught.

Both test layers were checked non-vacuous by mutation rather than trusted green:
- `DelayStage::reset` made to reallocate -> all 5 no_alloc reset tests fail
- `Engine::reset` stubbed to an early return -> 4 end-to-end tail tests fail (the other 5 correctly still pass — they test `Samplers`/`PitchShifter` directly or assert invariance)

## Follow-up, not done here

`recompute_tail` still duck-types on `delay_time`/`room_size`. Replacing it needs a *second* abstraction — a defaulted `tail_seconds()` — since `reset` doesn't answer "how long does this ring?". That would also delete the reverb-constant duplication in `engine.rs`.

Verified on the integration branch with all four gate items: 302 passed, 0 failed, lint clean.