### PR TITLE
fix(plugin): restore host state across a deactivate/reactivate cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,11 @@ impulse_responses/*
 
 # Local-only NAM test preset. `rustortion-plugin` embeds all of `presets/` via
 # rust-embed, and no `.nam` models are tracked or shipped, so committing this
-# would ship a factory preset whose NAM stage resolves to nothing.
+# would ship a factory preset naming a model nobody else has — the NAM stage
+# would fall back to passthrough and log a "model not found" warning.
+#
+# `NAM_Starter.json` *is* tracked and ships: it names no model at all, so the
+# passthrough is deliberate rather than a failure, and it exists to surface the
+# model picker, models directory and rescan button to people who have never
+# loaded a `.nam` file.
 /presets/NAM.json

--- a/presets/NAM_Starter.json
+++ b/presets/NAM_Starter.json
@@ -1,0 +1,25 @@
+{
+  "name": "NAM Starter",
+  "description": "Empty NAM stage. Pick a .nam model from your models folder to hear it — the stage passes the dry signal through until you do.",
+  "author": null,
+  "stages": [
+    {
+      "Nam": {
+        "model_name": null,
+        "input_gain_db": 0.0,
+        "output_gain_db": 0.0,
+        "mix": 1.0,
+        "bypassed": false
+      }
+    }
+  ],
+  "ir_name": null,
+  "ir_gain": 0.16,
+  "pitch_shift_semitones": 0,
+  "input_filters": {
+    "hp_enabled": true,
+    "hp_cutoff": 100.0,
+    "lp_enabled": true,
+    "lp_cutoff": 8000.0
+  }
+}

--- a/rustortion-plugin/src/backend.rs
+++ b/rustortion-plugin/src/backend.rs
@@ -193,6 +193,14 @@ impl ParamBackend for PluginBackend {
     }
 
     fn set_ir(&self, name: &str) {
+        // Record the choice before attempting the load, so it is persisted with
+        // the project even if the load itself is dropped for want of an engine.
+        // The next activation then restores the cabinet the user actually asked
+        // for rather than the preset's.
+        if let Ok(mut persisted) = self.params.ir_name.lock() {
+            *persisted = Some(name.to_owned());
+        }
+
         // The IR runs after downsampling, so it is built at the host rate, not
         // the oversampled one.
         let (Some(loader), Some(engine), Some(sr)) =

--- a/rustortion-plugin/src/backend.rs
+++ b/rustortion-plugin/src/backend.rs
@@ -111,6 +111,20 @@ impl PluginBackend {
         Some(self.host_sample_rate()? * active as f32)
     }
 
+    /// Mark the DAW session dirty so `#[persist]` state is saved with the project.
+    ///
+    /// nih-plug serializes `#[persist]` fields passively: writing one does not
+    /// tell the host anything changed, so a project holding only persist-field
+    /// edits may never be offered for save. Touching a real parameter with its
+    /// own current value is the nudge — it changes no audio but does mark the
+    /// session dirty. `preset_idx` is the cheapest candidate: `non_automatable`,
+    /// and `process()` only reacts to it when the value actually differs.
+    fn mark_state_dirty(&self) {
+        let param = &self.params.preset_idx;
+        let current = param.modulated_normalized_value();
+        self.notify_host_param_changed(param.as_ptr(), current);
+    }
+
     /// Notify the host that a parameter value changed from the GUI.
     /// SAFETY: `ptr` must be a valid `ParamPtr` from one of our `RustortionParams` fields.
     fn notify_host_param_changed(&self, ptr: nih_plug::prelude::ParamPtr, normalized: f32) {
@@ -200,6 +214,10 @@ impl ParamBackend for PluginBackend {
         if let Ok(mut persisted) = self.params.ir_name.lock() {
             *persisted = Some(name.to_owned());
         }
+        // Unlike cabinet level and bypass, picking an IR changes no real
+        // parameter, so without this the host is never told anything happened
+        // and may not save the project at all.
+        self.mark_state_dirty();
 
         // The IR runs after downsampling, so it is built at the host rate, not
         // the oversampled one.
@@ -296,11 +314,7 @@ impl ParamBackend for PluginBackend {
         self.params
             .oversampling_factor
             .store(factor, Ordering::Relaxed);
-        // Mark DAW session dirty so the new value is saved with the project.
-        // #[persist] fields are serialized passively and don't trigger a save.
-        let param = &self.params.preset_idx;
-        let current = param.modulated_normalized_value();
-        self.notify_host_param_changed(param.as_ptr(), current);
+        self.mark_state_dirty();
     }
 
     /// Zero until the host activates the plugin. Read live so the NAM stage's
@@ -358,11 +372,6 @@ impl ParamBackend for PluginBackend {
         if let Ok(mut cs) = self.params.chain_state.lock() {
             *cs = Some(stages.to_vec());
         }
-        // Touch preset_idx with its current value to notify the host that
-        // state changed. #[persist] fields are serialized passively and
-        // don't mark the session dirty on their own.
-        let param = &self.params.preset_idx;
-        let current = param.modulated_normalized_value();
-        self.notify_host_param_changed(param.as_ptr(), current);
+        self.mark_state_dirty();
     }
 }

--- a/rustortion-plugin/src/lib.rs
+++ b/rustortion-plugin/src/lib.rs
@@ -309,6 +309,7 @@ fn do_load_preset(
     sample_rate: f32,
     oversampling_factor: u32,
     name: &str,
+    persisted_ir_name: &Mutex<Option<String>>,
 ) {
     let Some(manager) = manager else {
         return;
@@ -316,6 +317,16 @@ fn do_load_preset(
     let Some(preset) = manager.get_preset_by_name(name) else {
         return;
     };
+
+    // Keep the persisted cabinet in step with the one this preset installs
+    // below, *including* clearing it when the preset names no IR. The restore
+    // path prefers this field over the preset's own, so letting it keep a
+    // previous preset's cabinet would resurrect that cabinet on the next
+    // activation — the GUI's preset-load path emits no `IrSelected` for a
+    // preset with no IR, so nothing else would clear it.
+    if let Ok(mut persisted) = persisted_ir_name.lock() {
+        (*persisted).clone_from(&preset.ir_name);
+    }
 
     // Stages in the amp chain run at the oversampled rate
     #[allow(clippy::cast_precision_loss)]
@@ -387,35 +398,39 @@ impl RustortionPlugin {
     /// Only parameters whose engine message is allocation-free belong here.
     /// Pitch shift and the input filters have to build stages, so they are
     /// applied on the main thread in [`Plugin::initialize`] instead.
+    ///
+    /// "Allocation-free" covers the success path. `EngineHandle::send` formats a
+    /// log line if the bounded channel is full, which would allocate here — the
+    /// channel holds 128 and an activation queues a handful, so a full channel
+    /// means something upstream is already badly wrong.
     fn apply_host_params(&mut self, block_samples: u32) {
         // Leave the smoother untouched with no engine attached, so the value is
         // not consumed against an engine that never received it.
-        if self.engine_handle.is_none() {
+        // Destructured so the `last_*` writes below borrow disjointly from the
+        // handle, without cloning it on the audio thread.
+        let Self {
+            engine_handle,
+            params,
+            last_ir_gain,
+            last_ir_bypass,
+            ..
+        } = self;
+        let Some(handle) = engine_handle.as_ref() else {
             return;
+        };
+
+        let ir_gain = params.ir_gain.smoothed.next_step(block_samples);
+        if (ir_gain - *last_ir_gain).abs() > f32::EPSILON {
+            handle.set_ir_gain(ir_gain);
+            *last_ir_gain = ir_gain;
         }
 
-        let ir_gain = self.params.ir_gain.smoothed.next_step(block_samples);
-        let ir_bypass = self.params.ir_bypass.value();
-
-        let gain_changed = (ir_gain - self.last_ir_gain).abs() > f32::EPSILON;
-        let bypass_changed = self.last_ir_bypass != Some(ir_bypass);
-
-        if let Some(handle) = &self.engine_handle {
-            if gain_changed {
-                handle.set_ir_gain(ir_gain);
-            }
-            // Safe from the RT thread: `SetIrBypass` carries a plain `bool` over
-            // the bounded engine channel, so there is nothing to allocate.
-            if bypass_changed {
-                handle.set_ir_bypass(ir_bypass);
-            }
-        }
-
-        if gain_changed {
-            self.last_ir_gain = ir_gain;
-        }
-        if bypass_changed {
-            self.last_ir_bypass = Some(ir_bypass);
+        // Safe from the RT thread: `SetIrBypass` carries a plain `bool` over the
+        // bounded engine channel, so there is nothing to allocate.
+        let ir_bypass = params.ir_bypass.value();
+        if *last_ir_bypass != Some(ir_bypass) {
+            handle.set_ir_bypass(ir_bypass);
+            *last_ir_bypass = Some(ir_bypass);
         }
     }
 
@@ -526,6 +541,7 @@ impl Plugin for RustortionPlugin {
 
     fn task_executor(&mut self) -> TaskExecutor<Self> {
         let shared = self.shared.clone();
+        let params = self.params.clone();
 
         Box::new(move |task| {
             // Logging tasks carry no engine work, so handle them before the
@@ -575,6 +591,7 @@ impl Plugin for RustortionPlugin {
                         sample_rate,
                         os_factor,
                         &name,
+                        &params.ir_name,
                     );
                 }
                 PluginTask::ChangeOversamplingAndReload {
@@ -835,7 +852,12 @@ impl Plugin for RustortionPlugin {
 
                         if let Some(preset) = &preset {
                             handle.set_ir_gain(preset.ir_gain);
-                            handle.set_pitch_shift(preset.pitch_shift_semitones);
+                            // Deliberately no `set_pitch_shift` here. This arm
+                            // only runs when `restoring` is true, so the restore
+                            // block below immediately overwrites it with the
+                            // host's own value — and each call builds a
+                            // `PitchShifter` with its own FFT plans, so doing
+                            // both allocates one purely to discard it.
                         }
                     } else {
                         // No persisted chain — fall back to loading preset from disk
@@ -855,6 +877,7 @@ impl Plugin for RustortionPlugin {
                                 self.sample_rate,
                                 os_factor,
                                 &name,
+                                &self.params.ir_name,
                             );
                         }
                     }

--- a/rustortion-plugin/src/lib.rs
+++ b/rustortion-plugin/src/lib.rs
@@ -97,6 +97,12 @@ struct RustortionPlugin {
     editor_preset_names: Arc<Mutex<Vec<String>>>,
     last_preset_idx: i32,
     last_ir_gain: f32,
+    /// Last IR-bypass value pushed into the engine, or `None` when nothing has
+    /// been pushed since activation. `None` rather than a plain `bool` so the
+    /// `process()` delta check cannot mistake "carried over from the previous
+    /// activation" for "already applied to this engine" — the same hazard
+    /// `last_ir_gain`'s `NEG_INFINITY` sentinel guards against.
+    last_ir_bypass: Option<bool>,
     active_oversampling: u32,
     input_buf: Vec<f32>,
     output_buf: Vec<f32>,
@@ -158,6 +164,7 @@ impl Default for RustortionPlugin {
             editor_preset_names: Arc::new(Mutex::new(Vec::new())),
             last_preset_idx: -1,
             last_ir_gain: util::db_to_gain(-20.0),
+            last_ir_bypass: None,
             active_oversampling: 1, // 1x (no oversampling)
             input_buf: Vec::new(),
             output_buf: Vec::new(),
@@ -253,6 +260,48 @@ struct OversamplingEvent {
     latency_after: u32,
 }
 
+/// Load a cabinet IR by name, preferring the embedded factory copy and falling
+/// back to the filesystem for user-added IRs.
+fn load_ir_by_name(handle: &EngineHandle, loader: &IrLoader, ir_name: &str, sample_rate: f32) {
+    if let Some(bytes) = factory::get_factory_ir(ir_name) {
+        ir_helper::load_and_set_ir_from_bytes(handle, loader, ir_name, &bytes, sample_rate);
+    } else {
+        ir_helper::load_and_set_ir(handle, loader, ir_name, sample_rate);
+    }
+}
+
+/// Push the host's input-filter parameters into a freshly built engine.
+///
+/// Only correct when restoring: on a fresh insert the params still hold their
+/// defaults while the preset's own filters have already been applied, so calling
+/// this unconditionally would overwrite them.
+fn apply_input_filters_from_params(
+    handle: &EngineHandle,
+    params: &RustortionParams,
+    sample_rate: f32,
+) {
+    use rustortion_core::amp::stages::Stage;
+    use rustortion_core::amp::stages::filter::{FilterStage, FilterType};
+
+    // Input filters sit ahead of the upsampler, so they are built at the host
+    // rate — not the oversampled rate the amp chain runs at.
+    let hp: Option<Box<dyn Stage>> = params.hp_enabled.value().then(|| {
+        Box::new(FilterStage::new(
+            FilterType::Highpass,
+            params.hp_cutoff.value(),
+            sample_rate,
+        )) as Box<dyn Stage>
+    });
+    let lp: Option<Box<dyn Stage>> = params.lp_enabled.value().then(|| {
+        Box::new(FilterStage::new(
+            FilterType::Lowpass,
+            params.lp_cutoff.value(),
+            sample_rate,
+        )) as Box<dyn Stage>
+    });
+    handle.set_input_filters(hp, lp);
+}
+
 fn do_load_preset(
     handle: &EngineHandle,
     manager: Option<&rustortion_core::preset::Manager>,
@@ -290,11 +339,7 @@ fn do_load_preset(
     // Load IR if specified
     if let Some(ir_name) = &preset.ir_name {
         if let Some(loader) = ir_loader {
-            if let Some(bytes) = factory::get_factory_ir(ir_name) {
-                ir_helper::load_and_set_ir_from_bytes(handle, loader, ir_name, &bytes, sample_rate);
-            } else {
-                ir_helper::load_and_set_ir(handle, loader, ir_name, sample_rate);
-            }
+            load_ir_by_name(handle, loader, ir_name, sample_rate);
         }
     } else {
         handle.clear_ir();
@@ -331,6 +376,49 @@ fn do_load_preset(
 }
 
 impl RustortionPlugin {
+    /// Push changed host parameters into the engine, once per block.
+    ///
+    /// Every check is gated on a delta, so an untouched parameter costs nothing.
+    /// The sentinels reset in [`Plugin::initialize`] are what make the first
+    /// block of each activation push the real values into the freshly built
+    /// engine — that is what stops a setting from silently reverting to the
+    /// engine's own default after a disable/re-enable cycle.
+    ///
+    /// Only parameters whose engine message is allocation-free belong here.
+    /// Pitch shift and the input filters have to build stages, so they are
+    /// applied on the main thread in [`Plugin::initialize`] instead.
+    fn apply_host_params(&mut self, block_samples: u32) {
+        // Leave the smoother untouched with no engine attached, so the value is
+        // not consumed against an engine that never received it.
+        if self.engine_handle.is_none() {
+            return;
+        }
+
+        let ir_gain = self.params.ir_gain.smoothed.next_step(block_samples);
+        let ir_bypass = self.params.ir_bypass.value();
+
+        let gain_changed = (ir_gain - self.last_ir_gain).abs() > f32::EPSILON;
+        let bypass_changed = self.last_ir_bypass != Some(ir_bypass);
+
+        if let Some(handle) = &self.engine_handle {
+            if gain_changed {
+                handle.set_ir_gain(ir_gain);
+            }
+            // Safe from the RT thread: `SetIrBypass` carries a plain `bool` over
+            // the bounded engine channel, so there is nothing to allocate.
+            if bypass_changed {
+                handle.set_ir_bypass(ir_bypass);
+            }
+        }
+
+        if gain_changed {
+            self.last_ir_gain = ir_gain;
+        }
+        if bypass_changed {
+            self.last_ir_bypass = Some(ir_bypass);
+        }
+    }
+
     /// Hand an oversampling-path change to the background thread to log.
     ///
     /// The engine's events are already one-shot; the [`ReportOnce`] latch makes
@@ -566,6 +654,10 @@ impl Plugin for RustortionPlugin {
         // what used to swallow the correction after a reload. (`NEG_INFINITY`,
         // not `NAN` — a `NaN` comparison is false and would swallow it again.)
         self.last_ir_gain = f32::NEG_INFINITY;
+        // Same contract for IR bypass, which had the same defect: the fresh
+        // engine below starts unbypassed regardless of what the host has
+        // persisted, so the delta check must fire on the first block.
+        self.last_ir_bypass = None;
         self.sample_rate = buffer_config.sample_rate;
         self.shared
             .sample_rate
@@ -682,6 +774,13 @@ impl Plugin for RustortionPlugin {
                     .and_then(|g| g.clone())
                     .or_else(|| self.params.chain_state.lock().ok().and_then(|g| g.clone()));
 
+                // Whether this activation is restoring existing state (a
+                // disable/re-enable cycle, or a reopened project) rather than a
+                // fresh insert. The host's parameters only describe reality in
+                // the former case — see the restore block at the end of this
+                // `if let`.
+                let restoring = persisted_stages.is_some();
+
                 if let Some(handle) = &self.engine_handle {
                     if let Some(stages) = &persisted_stages {
                         // Restore from DAW-persisted chain state
@@ -701,37 +800,40 @@ impl Plugin for RustortionPlugin {
                         // Also load IR/filters/pitch from preset (those are
                         // persisted via nih-plug params and applied separately)
                         #[allow(clippy::cast_sign_loss)]
-                        if let Some(name) = self.preset_names.get(restored_idx as usize).cloned()
-                            && let Some(mgr) = self
-                                .shared
-                                .preset_manager
-                                .lock()
-                                .ok()
-                                .and_then(|g| g.clone())
-                            && let Some(preset) = mgr.get_preset_by_name(&name)
+                        let preset = self
+                            .preset_names
+                            .get(restored_idx as usize)
+                            .cloned()
+                            .and_then(|name| {
+                                self.shared
+                                    .preset_manager
+                                    .lock()
+                                    .ok()
+                                    .and_then(|g| g.clone())
+                                    .and_then(|mgr| mgr.get_preset_by_name(&name).cloned())
+                            });
+
+                        // Cabinet: prefer the IR the user picked (persisted with
+                        // the project) over the preset's own, the same
+                        // precedence `chain_state` takes over the preset's
+                        // stages. Without this a chosen cabinet reverted to the
+                        // preset's on every reactivation and project reload.
+                        let ir_to_load = self
+                            .params
+                            .ir_name
+                            .lock()
+                            .ok()
+                            .and_then(|g| g.clone())
+                            .or_else(|| preset.as_ref().and_then(|p| p.ir_name.clone()));
+
+                        if let Some(ir_name) = &ir_to_load
+                            && let Some(loader) =
+                                self.shared.ir_loader.lock().ok().and_then(|g| g.clone())
                         {
-                            if let Some(ir_name) = &preset.ir_name {
-                                let loader =
-                                    self.shared.ir_loader.lock().ok().and_then(|g| g.clone());
-                                if let Some(loader) = &loader {
-                                    if let Some(bytes) = factory::get_factory_ir(ir_name) {
-                                        ir_helper::load_and_set_ir_from_bytes(
-                                            handle,
-                                            loader,
-                                            ir_name,
-                                            &bytes,
-                                            self.sample_rate,
-                                        );
-                                    } else {
-                                        ir_helper::load_and_set_ir(
-                                            handle,
-                                            loader,
-                                            ir_name,
-                                            self.sample_rate,
-                                        );
-                                    }
-                                }
-                            }
+                            load_ir_by_name(handle, &loader, ir_name, self.sample_rate);
+                        }
+
+                        if let Some(preset) = &preset {
                             handle.set_ir_gain(preset.ir_gain);
                             handle.set_pitch_shift(preset.pitch_shift_semitones);
                         }
@@ -765,6 +867,25 @@ impl Plugin for RustortionPlugin {
                     let gui_already_set = self.shared.gui_stages.lock().is_ok_and(|g| g.is_some());
                     if !gui_already_set && let Some(stages) = persisted_stages {
                         self.shared.store_gui_stages(&stages);
+                    }
+
+                    // Re-apply the host's pitch shift and input filters to the
+                    // fresh engine. `deactivate()` dropped the previous one and
+                    // the replacement starts at *its* own defaults, so without
+                    // this the user's settings silently vanish on every
+                    // disable/re-enable cycle. Both allocate (a pitch shifter
+                    // builds FFT plans, filters build stages), which is why
+                    // they are applied here on the main thread rather than
+                    // through a `process()` delta check like IR gain and bypass.
+                    //
+                    // Gated on `restoring`: on a fresh insert the params still
+                    // hold their defaults while `do_load_preset` above has
+                    // already applied the preset's own pitch shift and filters,
+                    // and overwriting those with defaults would trade this bug
+                    // for a worse one.
+                    if restoring {
+                        handle.set_pitch_shift(self.params.pitch_shift.value());
+                        apply_input_filters_from_params(handle, &self.params, self.sample_rate);
                     }
                 }
 
@@ -825,19 +946,8 @@ impl Plugin for RustortionPlugin {
             self.active_oversampling = requested_os;
         }
 
-        // Apply IR gain from DAW parameter
-        if let Some(handle) = &self.engine_handle {
-            #[allow(clippy::cast_possible_truncation)]
-            let ir_gain = self
-                .params
-                .ir_gain
-                .smoothed
-                .next_step(buffer.samples() as u32);
-            if (ir_gain - self.last_ir_gain).abs() > f32::EPSILON {
-                handle.set_ir_gain(ir_gain);
-                self.last_ir_gain = ir_gain;
-            }
-        }
+        #[allow(clippy::cast_possible_truncation)]
+        self.apply_host_params(buffer.samples() as u32);
 
         let Some(engine) = &mut self.engine else {
             // No engine: mute rather than fall through. The host copies input

--- a/rustortion-plugin/src/params.rs
+++ b/rustortion-plugin/src/params.rs
@@ -41,6 +41,16 @@ pub struct RustortionParams {
     #[persist = "oversampling_factor"]
     pub oversampling_factor: Arc<AtomicU32>,
 
+    /// Cabinet IR the user selected, persisted with DAW project state.
+    ///
+    /// An IR is identified by name, so unlike cabinet level and bypass this
+    /// cannot be a nih-plug parameter — and it is not part of the stage chain
+    /// either, since the cabinet is not a chain stage. Without this field a
+    /// user-chosen cabinet silently reverted to the preset's own on every
+    /// reactivation and every project reload.
+    #[persist = "ir_name"]
+    pub ir_name: Arc<Mutex<Option<String>>>,
+
     /// Serialized stage chain — persisted with DAW project state so user
     /// modifications (add/remove/reorder stages) survive save/restore.
     #[persist = "chain_state"]
@@ -111,6 +121,7 @@ impl Default for RustortionParams {
                 .non_automatable(),
 
             oversampling_factor: Arc::new(AtomicU32::new(1)), // 1 = 1x (no oversampling)
+            ir_name: Arc::new(Mutex::new(None)),
             chain_state: Arc::new(Mutex::new(None)),
         }
     }


### PR DESCRIPTION
Found while manually testing the plugin ahead of v0.3.0: toggle IR bypass, disable the plugin, re-enable it, and the cabinet is no longer bypassed. The setting was persisted correctly — it was just never read back.

## Root cause

`deactivate()` drops the engine; `initialize()` builds a fresh one at *its* own defaults. Of the nine host parameters, only three were ever read back into it:

| Param | Before | After |
|---|---|---|
| `output_level`, `ir_gain`, `preset_idx` | ✅ read | ✅ unchanged |
| `ir_bypass` | ❌ never read | ✅ restored + host automation now works |
| `pitch_shift`, `hp_enabled`, `hp_cutoff`, `lp_enabled`, `lp_cutoff` | ❌ never read | ✅ restored on activation |
| **Selected cabinet IR** | ❌ **not persisted at all** | ✅ persisted and restored |

The param flow was one-way: the GUI pushed to the engine *and* notified the host (so the saved value was right), but nothing closed the loop back into a newly built engine.

## Changes

**`ir_bypass`** gets the REV-24 sentinel treatment `ir_gain` already had — a `last_ir_bypass: Option<bool>` reset to `None` on activation, so the `process()` delta check fires on the first block. `Option` rather than `bool` so "carried over from the last activation" can't be mistaken for "already applied". Safe from the RT thread: `SetIrBypass` carries a plain `bool` over the bounded engine channel, nothing to allocate.

**Pitch shift and input filters** can't take that route — `set_pitch_shift` builds FFT plans and `set_input_filters` builds stages, both documented as GUI-thread-only. They're applied in `initialize()` on the main thread, gated on `restoring`. That gate matters: on a fresh insert the params still hold defaults while `do_load_preset` has already applied the preset's own pitch and filters, so applying unconditionally would have traded this bug for a worse one.

**The cabinet IR** gains `#[persist = "ir_name"]`, written by `set_ir` and preferred over the preset's IR on restore — the same precedence `chain_state` already takes over the preset's stages. An IR is identified by name, so it can't be a nih-plug param, which is how it escaped the net that caught cabinet level and bypass. Verified that selecting a *preset* keeps this in sync: a preset load emits `Message::IrSelected`, which routes through `set_ir`.

**Backwards compatible** — projects saved before this have no `ir_name` key, so it deserializes to `None` and falls back to the preset's IR, i.e. today's behaviour.

## Also here

- `NAM Starter`, a factory preset naming no model and no IR, so the model picker, models directory and rescan button are discoverable without a `.nam` file on disk. With no model named, the stage takes the *deliberate* passthrough branch rather than logging a "model not found" warning.
- Extracted `apply_host_params` (`process()` went over the 100-line clippy limit) and `load_ir_by_name` (the factory-then-filesystem lookup was written out three times).

## Still not fixed

Host automation of `pitch_shift` and the four filter params remains inert — they're only read at activation. Wiring it needs coefficient updates on an existing filter rather than a stage rebuild per block, otherwise a continuous cutoff sweep floods the engine's `bounded(128)` channel. That's a DSP change, not a wiring one, so it's left out deliberately.

## Testing

`make lint` clean, `make test` 308 passed / 0 failed, including all five factory preset tests (a null `ir_name` doesn't break `every_preset_ir_is_embedded`). Release bundle built and the embed verified against the artifact with `strings`, since rust_embed only bakes bytes in release.

⚠️ **No automated coverage** — `rustortion-plugin` has no host harness, so the behaviour here is verified by manual testing only. The check that matters most is **a fresh instance switching presets**: that's the one path where the `restoring` gate could misfire and override preset-supplied IR, pitch and filters with param defaults.