### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -36,19 +36,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # v0.3.0 ships the plugin for x86_64 Linux only. aarch64 needs a full
-          # arm64 sysroot (X11/xcb/GL/xkbcommon) for the iced_baseview GUI, which
-          # plain `gcc-aarch64-linux-gnu` does not provide — see README.
+          # Native runners on purpose — cross-compiling the iced_baseview GUI
+          # needs a full target sysroot for X11/xcb/GL/xkbcommon. Building on
+          # each target's own runner sidesteps that entirely. This matrix
+          # mirrors the `plugin` job in ci.yaml; keep them in sync.
           - label: linux-x86_64
             runner: ubuntu-latest
             arch_dir: x86_64-linux
+            vst3_lib: Rustortion.so
             asset: Rustortion-linux-x86_64.zip
+          - label: linux-aarch64
+            # Free for public repositories. Native arm64, no sysroot needed.
+            runner: ubuntu-24.04-arm
+            arch_dir: aarch64-linux
+            vst3_lib: Rustortion.so
+            asset: Rustortion-linux-aarch64.zip
+          - label: windows-x86_64
+            runner: windows-latest
+            arch_dir: x86_64-win
+            # On Windows the VST3 payload is a DLL that keeps the .vst3
+            # extension, not a .so — see nih_plug_xtask's
+            # `vst3_bundle_library_name`.
+            vst3_lib: Rustortion.vst3
+            asset: Rustortion-windows-x86_64.zip
     steps:
       - uses: actions/checkout@v6
         with:
           # Build exactly the code the release was cut from, not branch tip.
           ref: ${{ env.RELEASE_TAG }}
+      # X11/GL headers for the plugin GUI. Windows needs no equivalent — wgpu
+      # goes through DX12 and the window backend is win32.
       - name: Install system dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update && sudo apt-get install -y \
             libjack-jackd2-dev libasound2-dev pkg-config \
@@ -64,6 +83,7 @@ jobs:
       # No rust-cache here on purpose: release builds should not inherit a warm,
       # possibly polluted target/ directory.
       - name: Clean stale bundle output
+        shell: bash
         run: rm -rf target/bundled
       - name: Bundle plugin
         # `--profile dist` matches cargo-dist's release profile (lto = true,
@@ -71,10 +91,11 @@ jobs:
         # the standalone binary in the same release.
         run: cargo xtask bundle rustortion-plugin --profile dist --locked
       - name: Verify bundle structure
+        shell: bash
         run: |
           set -euo pipefail
           test -f target/bundled/Rustortion.clap
-          test -f "target/bundled/Rustortion.vst3/Contents/${{ matrix.arch_dir }}/Rustortion.so"
+          test -f "target/bundled/Rustortion.vst3/Contents/${{ matrix.arch_dir }}/${{ matrix.vst3_lib }}"
           unexpected="$(find target/bundled/Rustortion.vst3/Contents \
             -mindepth 1 -maxdepth 1 -not -name '${{ matrix.arch_dir }}' -print)"
           if [ -n "$unexpected" ]; then
@@ -83,11 +104,23 @@ jobs:
             exit 1
           fi
           find target/bundled
-      - name: Package
+      # `zip -y` keeps symlinks as symlinks. Windows has no `zip` binary, so it
+      # uses Compress-Archive instead — the Windows bundle has no symlinks to
+      # preserve, so the two produce equivalent archives.
+      - name: Package (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
         run: |
           set -euo pipefail
           zip -r -y "$GITHUB_WORKSPACE/${{ matrix.asset }}" \
             Rustortion.clap Rustortion.vst3
+        working-directory: target/bundled
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path Rustortion.clap, Rustortion.vst3 `
+            -DestinationPath "$env:GITHUB_WORKSPACE\${{ matrix.asset }}"
         working-directory: target/bundled
       - name: Upload to release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,58 @@
+## [0.3.0] - 2026-07-26
+
+### 🚀 Features
+
+- Add per-stage bypass toggle (#220)
+- Add nih-plug CLAP/VST3 plugin with GUI and preset support (#224)
+- Shared GUI via rustortion-ui with iced_baseview plugin editor (#225)
+- Assert no allocations on the RT audio path (#238)
+- Add NAM neural amp modeler stage (#243)
+- *(nam)* Bypass model on sample-rate mismatch and surface it in the UI (#244)
+- *(nam)* Folder management — editable dir, rescan, models-folder on stage card (#245)
+- *(nam)* Update to nam-rs 0.2.0 and support LSTM models (#248)
+- *(stages)* Add tremolo effect with sine→square killswitch shape (#258)
+
+### 🐛 Bug Fixes
+
+- Move IR loading off RT thread and drain engine messages (#213) (#215)
+- Forward parameter changes to live stages, eliminate rebuild clicks (#217)
+- Correct power amp sag, push-pull symmetry, and add sag_release (#218)
+- *(dsp)* Tube bug fixes (#223)
+- Shared oversampling control with race condition fixes (#227)
+- Bundle and load own font (#231)
+- *(ui)* Suffix slider step literals to satisfy float_literal_f32_fallback (#265)
+- *(tremolo)* Perceptual shape curve so the whole knob morphs (#259)
+- *(plugin)* Make the plugin honest for the v0.3.0 release (#268)
+- *(plugin)* Resolve the engine handle per call so the GUI survives a reload (#272)
+- *(preset)* Stop non-ASCII preset names from colliding on disk (#275)
+- *(standalone)* Report a missing JACK server instead of panicking (#277)
+- *(plugin)* Flush all DSP state on host transport reset (PLUG-2) (#276)
+- *(plugin)* Restore host state across a deactivate/reactivate cycle (#279)
+
+### 📚 Documentation
+
+- Trim CLAUDE.md and correct stage count and macro claims (#267)
+
+### ⚡ Performance
+
+- Per-block chain processing + batched NAM process_buffer (2.8×) (#249)
+- *(rt)* Eliminate permit_alloc sites on the RT audio path (#239) (#254)
+- *(rt)* Enable FTZ/DAZ on the audio thread and clean up denormal handling (#269)
+
+### 🧪 Testing
+
+- Add tests for preamp, compressor, tonestack, and noise gate stages (#221)
+- *(nam)* Guard model-name recall + document deferred automation (#246)
+
+### ⚙️ Miscellaneous Tasks
+
+- Edge case fixes and code cleanup (#222)
+- Fix linting issues (#235)
+- *(nam)* Update nam-rs to 0.3.0 from crates.io (#256)
+- *(ci)* Pin the Rust toolchain to 1.95.0 (#270)
+- *(plugin)* Build the plugin in CI and attach bundles to releases (#271)
+- *(plugin)* Build the plugin on aarch64 Linux and Windows (#274)
+- Delete the Korg D888 reverb IRs (#278)
 ## [0.2.0] - 2026-03-08
 
 ### 🚀 Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Workspace: `rustortion-core` (DSP, no GUI deps) · `rustortion-ui` (shared iced 
 ## Commands
 
 ```bash
-cargo run --release              # standalone (JACK/PipeWire must be running or it panics)
+cargo run --release              # standalone (needs JACK/PipeWire; exits 1 with a clear error if absent)
 make lint                        # fmt + clippy — exactly what CI runs
 make test                        # cargo test --workspace --all-targets --all-features
 make plugin                      # cargo xtask bundle rustortion-plugin --release
@@ -21,6 +21,20 @@ CI clippy: `-D warnings -D clippy::all -D clippy::pedantic -D clippy::nursery`. 
 carries its own `#![allow(...)]` block (they have drifted — see REV-20 in `claude/tasks.md`).
 
 System deps: `libjack-jackd2-dev libasound2-dev pkg-config`.
+
+Toolchain is pinned in `rust-toolchain.toml` (1.95.0). CI runs `@stable`, so an unpinned bump can
+turn a release build red *after* the tag is pushed — bump it in its own PR.
+
+## Releasing
+
+Tag push → `release.yml` (cargo-dist; builds the standalone for x86_64 + aarch64 Linux and calls
+`gh release create`) → `release: published` fires `plugin-release.yml`, which bundles the plugin
+natively on Linux x86_64, Linux aarch64 and Windows x86_64 and uploads the zips. The `published`
+trigger is load-bearing: a same-tag-push trigger races dist into a 404 on every upload.
+`release.yml` is dist-generated — never hand-edit it. Version lives in the four crate
+`Cargo.toml`s (kept in lockstep; `xtask` stays 0.1.0 and is `dist = false`). Changelog is
+`make changelog TAG=v0.3.0` — the `TAG` is required, since without it git-cliff files the
+commits you are releasing under `[unreleased]` instead of the version being cut.
 
 Dev profile uses `opt-level = 1` — IR convolution is unusably slow at `opt-level = 0`. Any
 performance claim must come from `--release`.
@@ -46,12 +60,16 @@ There are **12** registered stages. The `gui_stage_registry!` macro in
 `StageType`/`StageConfig` live in core and are **hand-maintained across ~9 match sites** in
 `rustortion-core/src/preset/stage_config.rs`. Adding a stage means:
 
-1. `rustortion-core/src/amp/stages/new_stage.rs` — implement the `Stage` trait
+1. `rustortion-core/src/amp/stages/new_stage.rs` — implement the `Stage` trait, including the
+   required `reset()` (zero every buffer/index in place; never allocate — hosts call it from the
+   RT thread)
 2. `rustortion-core/src/preset/stage_config.rs` — add the variant to every match (compiler will list them)
 3. `rustortion-ui/src/stages/new_stage.rs` — config, message, `apply()`, `view()`
 4. One line in the `gui_stage_registry!` invocation
 5. i18n keys in **both** EN and ZH_CN (`rustortion-ui/src/i18n/mod.rs`, `tr!()` macro)
-6. Slot params in `rustortion-plugin/src/params.rs`
+
+Nothing to add in `rustortion-plugin/src/params.rs` — stage parameters are not host-exposed
+(see Pitfalls).
 
 ## Pitfalls
 
@@ -69,8 +87,11 @@ There are **12** registered stages. The `gui_stage_registry!` macro in
   is async, off the RT thread. Keep convolver type configurable — FIR beat FFT on the Pi in real
   testing, and the TwoStage tail math is numerically wrong until REV-2 lands.
 - **iced_baseview** is a fork at `github.com/OpenSauce/iced_baseview` (unpinned git dep).
-- **Plugin per-slot params are not read by `process()`** — host automation of stage params is dead
-  until REF-Q3/REV-4 is resolved.
+- **The plugin exposes 9 global params only** (`params.rs`, ~117 lines): output level, IR gain/bypass,
+  pitch shift, HP/LP enable+cutoff, preset index. The nested per-slot param arrays were deleted in
+  REV-4 — they were never read by `process()`. Stage settings travel through `chain_state` (preset
+  JSON in the host's state blob), so they persist and recall correctly but are **not host-automatable**.
+  Exposing them properly is v0.4.0+ work.
 
 ## Conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "rustortion-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "rustortion-plugin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "crossbeam",
  "dirs",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "rustortion-standalone"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "rustortion-ui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "iced",

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,11 @@ plugin-install:
 	cp target/bundled/Rustortion.clap ~/.clap/
 	cp -r target/bundled/Rustortion.vst3 ~/.vst3/
 
+# TAG is required: without --tag, git-cliff files the commits you are about to
+# release under "[unreleased]" instead of the version being cut.
+#   make changelog TAG=v0.3.0
 changelog:
-	git-cliff -o CHANGELOG.md
+ifndef TAG
+	$(error TAG is required, e.g. `make changelog TAG=v0.3.0`)
+endif
+	git-cliff --tag $(TAG) -o CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ A guitar and bass amp simulator built in Rust. Runs standalone with JACK, or as 
 ## Features
 
 - Low-latency audio processing with configurable oversampling (1x–16x)
-- 11 DSP stages: preamp (with 12AX7 triode clipper), compressor, tone stack, power amp, noise gate, level, multi-band saturator, delay, reverb, 16-band graphic EQ, and NAM (Neural Amp Modeler) model loading (WaveNet + LSTM `.nam` files)
+- 12 DSP stages: preamp (with 12AX7 triode clipper), compressor, tone stack, power amp, noise gate, level, multi-band saturator, delay, reverb, tremolo, 16-band graphic EQ, and NAM (Neural Amp Modeler) model loading (WaveNet + LSTM `.nam` files)
+- Per-stage bypass and stage reordering within the chain
 - Impulse response cabinet simulation for both guitar and bass
 - Saving and loading presets with keyboard hotkey switching
 - Real-time recording capability
 - Built-in tuner
 - FFT-based pitch shifting for alternate tunings without retuning your instrument
 - MIDI controller support
-- VST3 and CLAP plugin builds for DAW use (experimental — see [Plugin](#vst3clap-plugin))
+- VST3 and CLAP plugin builds for DAW use — see [Plugin](#vst3clap-plugin)
 - Tabbed GUI with minimap, collapsible stage cards, and input filter controls - built with [Iced](https://github.com/iced-rs/iced)
 - English and Simplified Chinese UI
 
@@ -67,15 +68,25 @@ Rustortion also ships as an audio plugin in two formats: **CLAP** (`Rustortion.c
 **VST3** (`Rustortion.vst3`). Both are built from the same code and expose the same GUI as the
 standalone app.
 
-> [!NOTE]
-> Plugin builds are **Linux x86_64 only** for this release. There is no aarch64 (Raspberry Pi),
-> macOS, or Windows plugin build yet — cross-compiling the plugin GUI needs a full target sysroot
-> for X11/xcb/OpenGL, which the release pipeline does not have. On other platforms, build from
-> source (below) or use the standalone app.
+Bundles are published for three targets:
 
-Download `Rustortion-linux-x86_64.zip` from the
+| Download | Platform | Status |
+|---|---|---|
+| `Rustortion-linux-x86_64.zip` | Linux x86_64 | Tested in a DAW |
+| `Rustortion-linux-aarch64.zip` | Linux aarch64 (Raspberry Pi) | Builds in CI, not hand-tested |
+| `Rustortion-windows-x86_64.zip` | Windows x86_64 | Builds in CI, not hand-tested |
+
+> [!NOTE]
+> The aarch64 and Windows bundles are built natively in CI on every release, but have not been
+> loaded in a DAW by hand. They should work; if one doesn't, please open an issue. There is no
+> macOS build — it needs an Apple Developer ID for signing and notarization, without which a DAW
+> will refuse to load the plugin.
+
+Download the archive for your platform from the
 [releases page](https://github.com/OpenSauce/rustortion/releases/) and unpack both bundles into
 your plugin folders:
+
+On Linux (substitute `aarch64` for `x86_64` on a Pi):
 
 ```bash
 sudo apt-get install libjack-jackd2-0
@@ -86,7 +97,13 @@ cp -r Rustortion.vst3 ~/.vst3/
 ```
 
 `~/.clap` and `~/.vst3` are the standard per-user plugin directories on Linux; most hosts scan
-them by default. Rescan plugins in your DAW afterwards.
+them by default.
+
+On Windows, unzip `Rustortion-windows-x86_64.zip` and copy `Rustortion.clap` into
+`%COMMONPROGRAMFILES%\CLAP` and `Rustortion.vst3` into `%COMMONPROGRAMFILES%\VST3` (typically
+`C:\Program Files\Common Files\`).
+
+Rescan plugins in your DAW afterwards.
 
 To build the plugin from source instead:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,14 +13,15 @@
 ## 功能特性
 
 - 低延迟音频处理，支持可配置的过采样（1x–16x）
-- 11 个 DSP 处理级：前级放大（含 12AX7 三极管削波器）、压缩器、音色堆栈、后级放大、噪声门、电平、多频段饱和器、延迟、混响、16 频段图形均衡器，以及 NAM（Neural Amp Modeler）模型加载（支持 WaveNet 与 LSTM 的 `.nam` 文件）
+- 12 个 DSP 处理级：前级放大（含 12AX7 三极管削波器）、压缩器、音色堆栈、后级放大、噪声门、电平、多频段饱和器、延迟、混响、颤音、16 频段图形均衡器，以及 NAM（Neural Amp Modeler）模型加载（支持 WaveNet 与 LSTM 的 `.nam` 文件）
+- 支持单个处理级旁通，以及在链中调整处理级顺序
 - 支持吉他和贝斯的脉冲响应箱体模拟
 - 预设的保存与加载，支持键盘快捷键切换
 - 实时录音功能
 - 内置调音器
 - 基于 FFT 的变调功能，无需重新调弦即可切换至不同调音
 - MIDI 控制器支持
-- VST3 与 CLAP 插件构建，可在 DAW 中使用（实验性 — 参见[插件](#vst3clap-插件)）
+- VST3 与 CLAP 插件构建，可在 DAW 中使用 — 参见[插件](#vst3clap-插件)
 - 标签式界面，支持缩略图、可折叠级卡片和输入滤波器控制 - 使用 [Iced](https://github.com/iced-rs/iced) 构建
 - 界面支持英文与简体中文
 
@@ -63,7 +64,44 @@ cargo run --release
 
 ### VST3/CLAP 插件
 
-插件目前为实验性功能，尚未包含在发布版本中——需从源码构建：
+Rustortion 同时以两种插件格式发布：**CLAP**（`Rustortion.clap`）与 **VST3**（`Rustortion.vst3`）。
+两者由同一份代码构建，并提供与独立版应用相同的图形界面。
+
+目前发布以下三个目标平台的插件包：
+
+| 下载文件 | 平台 | 状态 |
+|---|---|---|
+| `Rustortion-linux-x86_64.zip` | Linux x86_64 | 已在 DAW 中实机测试 |
+| `Rustortion-linux-aarch64.zip` | Linux aarch64（树莓派） | CI 构建通过，未经实机测试 |
+| `Rustortion-windows-x86_64.zip` | Windows x86_64 | CI 构建通过，未经实机测试 |
+
+> [!NOTE]
+> aarch64 与 Windows 插件包会在每次发布时由 CI 原生构建，但尚未在 DAW 中人工加载测试。
+> 它们理论上可以正常工作；若遇到问题，欢迎提交 issue。目前没有 macOS 构建——它需要 Apple
+> Developer ID 进行代码签名与公证（notarization），否则 DAW 会拒绝加载该插件。
+
+请从[发布页面](https://github.com/OpenSauce/rustortion/releases/)下载对应平台的压缩包，
+并将两个插件包解压到您的插件目录。
+
+Linux（树莓派请将 `x86_64` 替换为 `aarch64`）：
+
+```bash
+sudo apt-get install libjack-jackd2-0
+unzip Rustortion-linux-x86_64.zip
+mkdir -p ~/.clap ~/.vst3
+cp -r Rustortion.clap ~/.clap/
+cp -r Rustortion.vst3 ~/.vst3/
+```
+
+`~/.clap` 与 `~/.vst3` 是 Linux 上标准的用户级插件目录，多数宿主会默认扫描这两个位置。
+
+Windows：解压 `Rustortion-windows-x86_64.zip`，将 `Rustortion.clap` 复制到
+`%COMMONPROGRAMFILES%\CLAP`，将 `Rustortion.vst3` 复制到 `%COMMONPROGRAMFILES%\VST3`
+（通常位于 `C:\Program Files\Common Files\`）。
+
+完成后请在您的 DAW 中重新扫描插件。
+
+若希望从源码构建插件：
 
 ```bash
 make plugin           # 构建 target/bundled/Rustortion.{clap,vst3}

--- a/rustortion-core/Cargo.toml
+++ b/rustortion-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustortion-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/rustortion-plugin/Cargo.toml
+++ b/rustortion-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustortion-plugin"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [lib]

--- a/rustortion-standalone/Cargo.toml
+++ b/rustortion-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustortion-standalone"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 repository = "https://github.com/OpenSauce/rustortion"
 default-run = "rustortion"

--- a/rustortion-ui/Cargo.toml
+++ b/rustortion-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustortion-ui"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Release prep for v0.3.0 — the code gate has been clear since #275–#279; this is mechanics plus doc catch-up.

## Version

Bumps `rustortion-core`, `-ui`, `-standalone`, `-plugin` from 0.2.0 → 0.3.0 (lockstep). `xtask` stays 0.1.0 and remains `dist = false`.

## Plugin ships for three platforms now

#274 proved the plugin builds natively green on aarch64 Linux and Windows x86_64, but those bundles only ever landed as expiring CI run artifacts. `plugin-release.yml` now mirrors ci.yaml's matrix, so all three attach to the release:

| Asset | Platform | Status |
|---|---|---|
| `Rustortion-linux-x86_64.zip` | Linux x86_64 | Hand-tested in a DAW |
| `Rustortion-linux-aarch64.zip` | Linux aarch64 | CI-built, not hand-tested |
| `Rustortion-windows-x86_64.zip` | Windows x86_64 | CI-built, not hand-tested |

This also closes the asymmetry where cargo-dist shipped the standalone for aarch64 but the plugin had no Pi build. Windows has no `zip` binary, so packaging splits into a `Compress-Archive` step; the apt block is gated on `runner.os == 'Linux'`.

## Docs

- **Both READMEs**: stage count was 11, tremolo (#258) made it 12; added per-stage bypass + reordering; dropped the "experimental" label from the plugin; replaced the stale platform note (it claimed cross-compilation was the blocker — #274 disproved that) with a per-platform download table.
- **README.zh-CN.md** was a release behind: it still said the plugin was experimental and unreleased, source-build only. Ported the whole plugin section.
- **CLAUDE.md**: the per-slot plugin params pitfall described nested arrays REV-4 deleted in #268; `cargo run --release` no longer panics without JACK (#277). Added a **Releasing** section documenting the load-bearing `release: published` trigger.
- **`make changelog` now requires `TAG`** — bare `git-cliff` files the commits you are releasing under `[unreleased]` instead of the version being cut, which is a quiet way to ship an empty changelog section.

## Verification

`make lint` clean under the full CI gate (`-D warnings -D clippy::all -D clippy::pedantic -D clippy::nursery`); `make test` = **308 passed, 0 failed**. Includes #273's dependency bump, merged first so the lockfile is verified here rather than at tag time.

Tag `v0.3.0` goes on main once this lands.