### PR TITLE
fix(release): stop dist building the plugin during the standalone release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ cd rustortion-standalone-x86_64-unknown-linux-gnu
 ./rustortion
 ```
 
-> [!NOTE]
-> The standalone archive was named `rustortion-<target>.tar.xz` up to v0.2.0. From v0.3.0 it is
-> `rustortion-standalone-<target>.tar.xz`, following the crate rename. The binary inside is still
-> `rustortion`. Substitute `aarch64` for `x86_64` on a Raspberry Pi.
-
 ### Running/Building from Source
 
 With the rust toolchain installed, you can clone the repository and run the application:

--- a/README.md
+++ b/README.md
@@ -42,10 +42,15 @@ You can download a tarball of a pre-built binary from the [releases page.](https
 
 ```bash
 sudo apt-get install libjack-jackd2-0
-tar -xf rustortion-x86_64-unknown-linux-gnu.tar.xz
-cd rustortion-x86_64-unknown-linux-gnu
+tar -xf rustortion-standalone-x86_64-unknown-linux-gnu.tar.xz
+cd rustortion-standalone-x86_64-unknown-linux-gnu
 ./rustortion
 ```
+
+> [!NOTE]
+> The standalone archive was named `rustortion-<target>.tar.xz` up to v0.2.0. From v0.3.0 it is
+> `rustortion-standalone-<target>.tar.xz`, following the crate rename. The binary inside is still
+> `rustortion`. Substitute `aarch64` for `x86_64` on a Raspberry Pi.
 
 ### Running/Building from Source
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,10 +41,15 @@
 
 ```bash
 sudo apt-get install libjack-jackd2-0
-tar -xf rustortion-x86_64-unknown-linux-gnu.tar.xz
-cd rustortion-x86_64-unknown-linux-gnu
+tar -xf rustortion-standalone-x86_64-unknown-linux-gnu.tar.xz
+cd rustortion-standalone-x86_64-unknown-linux-gnu
 ./rustortion
 ```
+
+> [!NOTE]
+> 在 v0.2.0 及更早版本中，独立版压缩包名为 `rustortion-<target>.tar.xz`；自 v0.3.0 起，
+> 随着 crate 重命名，压缩包名为 `rustortion-standalone-<target>.tar.xz`。包内的可执行文件
+> 仍为 `rustortion`。树莓派请将 `x86_64` 替换为 `aarch64`。
 
 ### 从源码运行/编译
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,11 +46,6 @@ cd rustortion-standalone-x86_64-unknown-linux-gnu
 ./rustortion
 ```
 
-> [!NOTE]
-> 在 v0.2.0 及更早版本中，独立版压缩包名为 `rustortion-<target>.tar.xz`；自 v0.3.0 起，
-> 随着 crate 重命名，压缩包名为 `rustortion-standalone-<target>.tar.xz`。包内的可执行文件
-> 仍为 `rustortion`。树莓派请将 `x86_64` 替换为 `aarch64`。
-
 ### 从源码运行/编译
 
 安装好 Rust 工具链后，您可以克隆仓库并运行应用程序：

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,9 +19,44 @@ install-updater = false
 include = ["impulse_responses", "presets", "README.md", "LICENSE"]
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
+# TEMPORARY - remove before merge. Builds release artifacts on the PR so the
+# apt fix below is proven on the real runners instead of at tag time.
+pr-run-mode = "upload"
 
+# dist builds the whole workspace, so the release build compiles
+# rustortion-plugin too — and that pulls iced_baseview -> baseview -> the `x11`
+# crate, whose build script hard-requires x11-xcb via pkg-config. v0.2.0
+# predates the plugin crate (#224), so the first tag after it (v0.3.0) was the
+# first time this list was ever insufficient, and it failed *after* the tag was
+# pushed.
+#
+# Keep this in sync with the apt list in .github/workflows/ci.yaml — if CI can
+# build the workspace and this cannot, the difference shows up only at tag time.
 [dist.dependencies.apt]
 libjack-jackd2-dev = '*'
 pkg-config = '*'
 libasound2-dev = '*'
 libgl-dev = '*'
+libx11-dev = '*'
+libx11-xcb-dev = '*'
+libxcb1-dev = '*'
+libxcursor-dev = '*'
+libxfixes-dev = '*'
+libxft-dev = '*'
+libxi-dev = '*'
+libxinerama-dev = '*'
+libxmu-dev = '*'
+libxrandr-dev = '*'
+libxrender-dev = '*'
+libxss-dev = '*'
+libxt-dev = '*'
+libxtst-dev = '*'
+libxxf86vm-dev = '*'
+libxkbcommon-dev = '*'
+libxkbcommon-x11-dev = '*'
+libxpresent-dev = '*'
+libxcb-render0-dev = '*'
+libxcb-shape0-dev = '*'
+libxcb-xfixes0-dev = '*'
+libxcb-icccm4-dev = '*'
+libxcb-dri2-0-dev = '*'

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,44 +19,26 @@ install-updater = false
 include = ["impulse_responses", "presets", "README.md", "LICENSE"]
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
+# Build only the packages that actually produce release artifacts, i.e. the
+# `rustortion` bin from rustortion-standalone.
+#
+# Without this, dist runs `cargo build --workspace` and compiles every member —
+# including rustortion-plugin, whose iced_baseview -> baseview dep needs x11-xcb
+# headers at build time. That plugin build is pure waste here: its output is
+# discarded, and plugin-release.yml builds the real bundles on `release:
+# published`. It also broke the v0.3.0 tag, because the apt list below covers
+# what the standalone needs (x11-dl, dlopened at runtime) and not what baseview
+# needs, and nothing on the PR path exercises the dist build.
+precise-builds = true
 # TEMPORARY - remove before merge. Builds release artifacts on the PR so the
-# apt fix below is proven on the real runners instead of at tag time.
+# fix is proven on the real runners instead of at tag time.
 pr-run-mode = "upload"
 
-# dist builds the whole workspace, so the release build compiles
-# rustortion-plugin too — and that pulls iced_baseview -> baseview -> the `x11`
-# crate, whose build script hard-requires x11-xcb via pkg-config. v0.2.0
-# predates the plugin crate (#224), so the first tag after it (v0.3.0) was the
-# first time this list was ever insufficient, and it failed *after* the tag was
-# pushed.
-#
-# Keep this in sync with the apt list in .github/workflows/ci.yaml — if CI can
-# build the workspace and this cannot, the difference shows up only at tag time.
+# Only the packages the *standalone* needs. It reaches X11 through x11-dl,
+# which dlopens at runtime and needs nothing at build time — see precise-builds
+# above for why the plugin's build-time X11 requirements are not our problem.
 [dist.dependencies.apt]
 libjack-jackd2-dev = '*'
 pkg-config = '*'
 libasound2-dev = '*'
 libgl-dev = '*'
-libx11-dev = '*'
-libx11-xcb-dev = '*'
-libxcb1-dev = '*'
-libxcursor-dev = '*'
-libxfixes-dev = '*'
-libxft-dev = '*'
-libxi-dev = '*'
-libxinerama-dev = '*'
-libxmu-dev = '*'
-libxrandr-dev = '*'
-libxrender-dev = '*'
-libxss-dev = '*'
-libxt-dev = '*'
-libxtst-dev = '*'
-libxxf86vm-dev = '*'
-libxkbcommon-dev = '*'
-libxkbcommon-x11-dev = '*'
-libxpresent-dev = '*'
-libxcb-render0-dev = '*'
-libxcb-shape0-dev = '*'
-libxcb-xfixes0-dev = '*'
-libxcb-icccm4-dev = '*'
-libxcb-dri2-0-dev = '*'

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -30,9 +30,6 @@ allow-dirty = ["ci"]
 # what the standalone needs (x11-dl, dlopened at runtime) and not what baseview
 # needs, and nothing on the PR path exercises the dist build.
 precise-builds = true
-# TEMPORARY - remove before merge. Builds release artifacts on the PR so the
-# fix is proven on the real runners instead of at tag time.
-pr-run-mode = "upload"
 
 # Only the packages the *standalone* needs. It reaches X11 through x11-dl,
 # which dlopens at runtime and needs nothing at build time — see precise-builds


### PR DESCRIPTION
The `v0.3.0` tag build failed on both Linux targets. No release was published — `host` never ran, so nothing shipped and 0.2.0 is still latest on the releases page.

## Root cause

```
thread 'main' panicked at x11-2.21.0/build.rs:42:14:
pkg-config exited with status code 1
  > pkg-config --libs --cflags x11-xcb 'x11-xcb >= 1.6'
  No package 'x11-xcb' found
```

dist logs its invocation as:

```
building x86_64-unknown-linux-gnu target, using cargo profile dist --workspace)
```

`cargo build --workspace` compiles **every** workspace member, including `rustortion-plugin` → `iced_baseview` → `baseview` → the `x11` crate, whose build script hard-requires `x11-xcb` headers. That plugin build is pure waste in this job: its output is discarded, and `plugin-release.yml` builds the real CLAP/VST3 bundles on `release: published`.

**Why it was never caught.** v0.2.0 predates the plugin crate (#224), so v0.3.0 was the first tag with the plugin in the workspace. Nothing on the PR path exercises the dist build — `ci.yaml` installs a full X11 set and goes green, while `release.yml` derives its packages from `dist-workspace.toml`. The two diverged silently, and the difference only surfaces *after* a tag is pushed.

## Fix

`precise-builds = true` narrows the build to the packages that actually produce release artifacts.

dist already knew what to ship — `rustortion-standalone` is the only package with a `[[bin]]`, `xtask` is `dist = false`, and core/ui/plugin are libraries. The bug was only in what it *compiled* to get there.

The standalone reaches X11 through `x11-dl`, which `dlopen`s at runtime and needs nothing at build time, so the original four apt packages were correct all along. An earlier revision of this PR added the plugin's ~20 X11 dev packages to the dist apt list; that treated the symptom and is reverted.

Verified with `dist plan` (local dist is 0.30.2, same as CI): identical artifacts, apt list back to four packages. No `release.yml` regeneration needed — it reads the matrix from the `plan` job at runtime.

## Also here

Both READMEs told users to download `rustortion-<target>.tar.xz`. dist names the archive after the package, which became `rustortion-standalone`, so v0.3.0 ships `rustortion-standalone-<target>.tar.xz`. The binary inside is still `rustortion`. This has been wrong since the crate split — it predates this branch and is unrelated to the build failure.

## Verification

`pr-run-mode = "upload"` is set **temporarily** so this PR runs `build-local-artifacts` on the real runners instead of skipping it. Once both targets are green I'll drop that line and merge, so the thing that failed at tag time is proven before the tag moves.

Then: delete and re-tag `v0.3.0` on the fixed commit, regenerating the changelog after the tag is removed so this fix lands in the 0.3.0 section rather than leaking into 0.4.0's.