### PR TITLE
fix(ci): give the release-notes job a repo to talk to

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -160,6 +160,10 @@ jobs:
       - name: Append plugin download table
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no actions/checkout, so gh cannot infer the repo from a
+          # git remote — without GH_REPO it fails with "not a git repository".
+          # Setting it is cheaper than checking out the tree just to name a repo.
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           body="$(gh release view "$RELEASE_TAG" --json body --jq '.body')"


### PR DESCRIPTION
Follow-up to #282. The Windows upload fix worked — all three plugin bundles are attached to v0.3.0 — but the new `notes` job failed:

```
gh release view "$RELEASE_TAG" --json body --jq '.body'
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The job deliberately has no `actions/checkout` (it only edits a release, it needs no source), so `gh` had no git remote to infer the repository from. `GH_REPO` tells it directly, which is cheaper than checking out the tree just to name a repo.

Only the notes step was affected — every bundle upload in that run succeeded, including the Windows one repaired by #282's `shell: bash` fix.

## v0.3.0 status

Complete and published. All four archives attached, and the plugin download table was applied by hand with the same content and marker the job generates, so a future re-dispatch for that tag will correctly skip it as already present.

This change makes the next release do it unattended.

## Verification

Same limitation as #282: the `notes` job only runs off a real release, so this gets its first live exercise at v0.4.0. The generated markdown itself is verified — it's exactly what was published to v0.3.0.